### PR TITLE
Update header.py

### DIFF
--- a/generator/templates/header.py
+++ b/generator/templates/header.py
@@ -175,15 +175,20 @@ def find_lib():
     elif sys.platform.startswith('darwin'):
         # FIXME: should find a means to configure path
         d = '/Applications/VLC.app/Contents/MacOS/'
+        c = d + 'lib/libvlccore.dylib'
         p = d + 'lib/libvlc.dylib'
-        if os.path.exists(p):
+        if os.path.exists(p) and os.path.exists(c):
+            # pre-load libvlccore VLC 2.2.8+
+            ctypes.CDLL(c)
             dll = ctypes.CDLL(p)
             for p in ('modules', 'plugins'):
                 p = d + p
                 if os.path.isdir(p):
                     plugin_path = p
                     break
-        else:  # hope, some PATH is set...
+        else:  # hope, some [DY]LD_LIBRARY_PATH is set...
+            # pre-load libvlccore VLC 2.2.8+
+            ctypes.CDLL('libvlccore.dylib')
             dll = ctypes.CDLL('libvlc.dylib')
 
     else:


### PR DESCRIPTION
On macOS, force loading of libvlccore.dylib before libvlc.dylib, required since VLC 2.2.8+.  Tested with VLC 2.2.8, 2.2.6 and 2.2.2 on macOS 10.13.3 High Sierra.