### PR TITLE
Another tkvlc.py update for macOS.

### DIFF
--- a/examples/tkvlc.py
+++ b/examples/tkvlc.py
@@ -1,7 +1,6 @@
 #! /usr/bin/python
 # -*- coding: utf-8 -*-
 
-#
 # tkinter example for VLC Python bindings
 # Copyright (C) 2015 the VideoLAN team
 #
@@ -19,13 +18,16 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
 #
-"""A simple example for VLC python bindings using tkinter. Uses python 3.4
+"""A simple example for VLC python bindings using tkinter.
+
+Requires Python 3.4 or later.
 
 Author: Patrick Fay
 Date: 23-09-2015
 """
 
-__version__ = '19.07.24'  # mrJean1 at Gmail dot com
+# Tested with Python 3.7.4, tkinter/Tk 8.6.9 on macOS 10.13.6 only.
+__version__ = '19.07.28'  # mrJean1 at Gmail dot com
 
 # import external libraries
 import vlc
@@ -35,14 +37,15 @@ if sys.version_info[0] < 3:
     import Tkinter as Tk
     from Tkinter import ttk
     from Tkinter.filedialog import askopenfilename
+    from Tkinter.tkMessageBox import showerror
 else:
     import tkinter as Tk
     from tkinter import ttk
     from tkinter.filedialog import askopenfilename
+    from tkinter.messagebox import showerror
 import os
 from os.path import basename, expanduser, isfile, join as joined
 from pathlib import Path
-from threading import Thread, Event
 import time
 
 _isMacOS   = sys.platform.startswith('darwin')
@@ -72,142 +75,211 @@ if _isMacOS:
             return None
         libtk = 'N/A'
 
-    def _shortcut(label, key, callback):
-        # XXX key shows in the menu, but doesn't work while video plays
-        return dict(label=label, accelerator='Command-' + key,
-                                 command=callback)
+    # _Shift   = 1   # if set, Shift key is down
+    # _Lock    = 2   # if set, Caps Lock key is down
+    # _Control = 4   # if set, Control key is down
+    _Mod1      = 8   # if set, Command key is down
+    # _Mod2    = 16  # if set, Option key is down
+    # etc. ... several more see tkinter.__init__.py at
+    # <https://GitHub.com/python/cpython/blob/master/
+    # Lib/tkinter/__init__.py> in method Event.__repr__.
 
-else:  # *nix, Xwindows and Windows
-    def _shortcut(label, key, callback):
-        return dict(label=label, underline=label.upper().index(key),
-                                 command=callback)
+    # The Tk modifier for the macOS Command key is called
+    # Meta, but there is only Meta_L, no Meta_R and both
+    # keyboard command keys generate Meta_L events.  Same
+    # for the macOS Option key, the modified is called Alt
+    # and there's only Alt_L, no Alt_R and both keyboard
+    # option keys generate Alt_L events. See answers at:
+    # <https://StackOverflow.com/questions/6378556/
+    # multiple-key-event-bindings-in-tkinter-control-e-command-apple-e-etc>
+
+    def _handle_shortcuts(event):  # all KeyPress events
+        # .state is <int> for for KeyPress and -Release
+        # XXX use if .state in (_Mod1, _Shift|_Mod1) ...
+        # menu items with shortcuts specified without the
+        # Shift- accelerator do flash for shift-key press
+        if event.state == _Mod1 and event.char in _Tk_Menu._shortcuts:
+            _Tk_Menu._shortcuts[event.char](event)
+
+else:  # *nix, Xwindows and Windows, UNTESTED
+
     libtk = 'N/A'
 
 
-class ttkTimer(Thread):
-    """a class serving same function as wxTimer... but there may be better ways to do this
-    """
-    def __init__(self, callback, tick):
-        Thread.__init__(self)
-        self.callback = callback
-        self.stopFlag = Event()
-        self.tick = tick
-        self.iters = 0
+class _Tk_Menu(Tk.Menu):
+    '''Tk.Menu extended with .add_shortcut method.
 
-    def run(self):
-        while not self.stopFlag.wait(self.tick):
-            self.iters += 1
-            self.callback()
+       Note, this is a kludge just to get Command-key shortcuts to
+       work on macOS.  Other modifiers like Ctrl-, Shift- and Option-
+       are not handled in this code.
+    '''
+    _shortcuts = {}  # XXX should be an instance attribute, not global
+    _shortcuts_bind = None
 
-    def stop(self):
-        self.stopFlag.set()
+    def add_shortcut(self, label='', key='', command=None, **kwds):
+        '''Like Tk.menu.add_command extended with shortcut key.
+        '''
+        # <https://TkDocs.com/tutorial/menus.html>
+        if not key:
+            self.add_command(label=label, command=command, **kwds)
+        elif len(key) > 1:  # XXX single char only
+            raise NotImplemented('shortcut key: %r[%s]' % (key, len(key)))
 
-    def get(self):
-        return self.iters
+        elif _isMacOS:
+            # keys show as upper-case, always
+            self.add_command(label=label, accelerator='Command-' + key,
+                                          command=command, **kwds)
+            # The accelerator modifiers on macOS are Ctrl-, Option-,
+            # Shift- and Command-, but for .bind use Ctrl-, Shift-,
+            # Mod1- instead of Command and Mod2- instead of Option.
+            # However, .bind does not seem to work that anyway, so ...
+            # if self._shortcuts_bind:
+            #     self._shortcuts_bind.bind('Mod1-' + key, command)
+            _Tk_Menu._shortcuts[key] = command  # ... use a kludge
+
+        else:  # XXX not tested, not tested, not tested
+            self.add_command(label=label, underline=label.lower().index(key),
+                                          command=command, **kwds)
+            if self._shortcuts_bind:
+                self._shortcuts_bind.bind('Control-%s>' % (key,), command)
+
+    def bind_shortcuts(self, frame):
+        '''Bind the handler for the shortcut keys.
+        '''
+        self._shortcuts_bind = frame
+        if _isMacOS:  # handler command keys only for now
+            frame.bind('<Key>', _handle_shortcuts)
 
 
 class Player(Tk.Frame):
     """The main window has to deal with events.
     """
+
     def __init__(self, parent, title=None, video=''):
         Tk.Frame.__init__(self, parent)
 
-        self.parent = parent
+        self.parent = parent  # == root
         self.parent.title(title or "tkVLCplayer")
-        self.video = video
+        self.video = expanduser(video)
 
         # Menu Bar
         #   File Menu
         menubar = Tk.Menu(self.parent)
         self.parent.config(menu=menubar)
 
-        fileMenu = Tk.Menu(menubar)
-        fileMenu.add_command(**_shortcut("Open", 'O', self.OnOpen))
+        fileMenu = _Tk_Menu(menubar)
+        fileMenu.bind_shortcuts(parent)  # XXX must be root?
+
+        fileMenu.add_shortcut("Open...", 'o', self.OnOpen)
         fileMenu.add_separator()
-        fileMenu.add_command(label="Play", command=self.OnPlay)
-        fileMenu.add_command(**_shortcut("Pause", 'P', self.OnPause))
+        fileMenu.add_shortcut("Play", 'p', self.OnPlay)  # Play/Pause
         fileMenu.add_command(label="Stop", command=self.OnStop)
         fileMenu.add_separator()
-        fileMenu.add_command(**_shortcut("Mute", 'M', self.OnSetVolume))
+        fileMenu.add_shortcut("Mute", 'm', self.OnMute)
         fileMenu.add_separator()
-        fileMenu.add_command(**_shortcut("Exit", 'X', _quit))
+        fileMenu.add_shortcut("Close", 'w' if _isMacOS else 's', self.OnClose)
         menubar.add_cascade(label="File", menu=fileMenu)
+        self.fileMenu = fileMenu
+        self.playIndex = fileMenu.index('Play')
+        self.muteIndex = fileMenu.index('Mute')
 
-        # The second panel holds controls
-        self.player = None
+        # first, top panel shows video
         self.videopanel = ttk.Frame(self.parent)
-        self.canvas = Tk.Canvas(self.videopanel).pack(fill=Tk.BOTH,expand=1)
-        self.videopanel.pack(fill=Tk.BOTH,expand=1)
+        self.canvas = Tk.Canvas(self.videopanel)
+        self.canvas.pack(fill=Tk.BOTH, expand=1)
+        self.videopanel.pack(fill=Tk.BOTH, expand=1)
 
-        ctrlpanel = ttk.Frame(self.parent)
-        pause  = ttk.Button(ctrlpanel, text="Pause", command=self.OnPause)
-        play   = ttk.Button(ctrlpanel, text="Play", command=self.OnPlay)
-        stop   = ttk.Button(ctrlpanel, text="Stop", command=self.OnStop)
-        volume = ttk.Button(ctrlpanel, text="Mute", command=self.OnSetVolume)
-        pause.pack(side=Tk.LEFT)
-        play.pack(side=Tk.LEFT)
+        # panel to hold buttons
+        buttons = ttk.Frame(self.parent)
+        self.playButton = ttk.Button(buttons, text="Play", command=self.OnPlay)
+        stop            = ttk.Button(buttons, text="Stop", command=self.OnStop)
+        self.muteButton = ttk.Button(buttons, text="Mute", command=self.OnMute)
+        self.playButton.pack(side=Tk.LEFT)
         stop.pack(side=Tk.LEFT)
-        volume.pack(side=Tk.LEFT)
-        self.volume_var = Tk.IntVar()
-        self.volslider = Tk.Scale(ctrlpanel, variable=self.volume_var, command=self.volume_sel,
-                                  from_=0, to=100, orient=Tk.HORIZONTAL, length=100)
-        self.volslider.pack(side=Tk.LEFT)
-        ctrlpanel.pack(side=Tk.BOTTOM)
+        self.muteButton.pack(side=Tk.LEFT)
+        self.muted = False
 
-        ctrlpanel2 = ttk.Frame(self.parent)
-        self.scale_var = Tk.DoubleVar()
-        self.timeslider_last_val = ""
-        self.timeslider = Tk.Scale(ctrlpanel2, variable=self.scale_var, command=self.scale_sel,
-                                   from_=0, to=1000, orient=Tk.HORIZONTAL, length=500)
-        self.timeslider.pack(side=Tk.BOTTOM, fill=Tk.X,expand=1)
-        self.timeslider_last_update = time.time()
-        ctrlpanel2.pack(side=Tk.BOTTOM,fill=Tk.X)
+        self.volMuted = ''
+        self.volVar = Tk.IntVar()
+        self.volSlider = Tk.Scale(buttons, variable=self.volVar, command=self.OnVolume,
+                                  from_=0, to=100, orient=Tk.HORIZONTAL, length=200,
+                                  showvalue=0, label='Volume')
+        self.volSlider.pack(side=Tk.LEFT)
+        buttons.pack(side=Tk.BOTTOM)
+
+        # panel to hold time slider
+        timers = ttk.Frame(self.parent)
+        self.timeVar = Tk.DoubleVar()
+        self.timeSliderLast = 0
+        self.timeSlider = Tk.Scale(timers, variable=self.timeVar, command=self.OnTime,
+                                   from_=0, to=1000, orient=Tk.HORIZONTAL, length=500,
+                                   showvalue=0)  # label='Time',
+        self.timeSlider.pack(side=Tk.BOTTOM, fill=Tk.X, expand=1)
+        self.timeSliderUpdate = time.time()
+        timers.pack(side=Tk.BOTTOM, fill=Tk.X)
 
         # VLC player controls
         self.Instance = vlc.Instance()
         self.player = self.Instance.media_player_new()
 
-        # below is a test, now use the File->Open file menu
-        #media = self.Instance.media_new('output.mp4')
-        #self.player.set_media(media)
-        #self.player.play() # hit the player button
-        #self.player.video_set_deinterlace(str_to_bytes('yadif'))
-
-        self.timer = ttkTimer(self.OnTimer, 1.0)
-        self.timer.start()
         self.parent.update()
 
-        #self.player.set_hwnd(self.GetHandle()) # for windows, OnOpen does this
+        self.OnTick()  # set the timer up
 
-    def OnExit(self, evt):
-        """Closes the window.
+    def OnClose(self, *unused):
+        """Closes the window and quit.
         """
-        self.Close()
+        # print("_quit: bye")
+        self.parent.quit()  # stops mainloop
+        self.parent.destroy()  # this is necessary on Windows to avoid
+        # ... Fatal Python Error: PyEval_RestoreThread: NULL tstate
+        os._exit(1)
 
-    def OnOpen(self):
+    def OnMute(self, *unused):
+        """Mute/Unmute audio.
+
+           Note, audio un/mute may be unreliable, see vlc.py docs.
+        """
+        self.muted = m = not self.muted  # self.player.audio_get_mute()
+        self.player.audio_set_mute(m)
+        u = "Unmute" if m else "Mute"
+        self.fileMenu.entryconfig(self.muteIndex, label=u)
+        self.muteButton.config(text=u)
+        # update the volume slider
+        self.OnVolume()
+
+    def OnOpen(self, *unused):
         """Pop up a new dialow window to choose a file, then play the selected file.
         """
         # if a file is already running, then stop it.
         self.OnStop()
+        # Create a file dialog opened in the current home directory, where
+        # you can display all kind of files, having as title "Choose a video".
+        video = askopenfilename(initialdir = Path(expanduser("~")),
+                                title = "Choose a video",
+                                filetypes = (("all files", "*.*"),
+                                             ("mp4 files", "*.mp4"),
+                                             ("mov files", "*.mov")))
+        self._Play(video)
 
-        if self.video:
-            video = expanduser(self.video)
-            self.video = ''
-        else:
-            # Create a file dialog opened in the current home directory, where
-            # you can display all kind of files, having as title "Choose a video".
-            video = askopenfilename(initialdir = Path(expanduser("~")),
-                                    title = "Choose a video",
-                                    filetypes = (("all files", "*.*"),
-                                                 ("mp4 files", "*.mp4"), ("mov files", "*.mov")))
-        if isfile(video):
-            # Creation
-            self.Media = self.Instance.media_new(str(video))
-            self.player.set_media(self.Media)
+    def _Pause(self, playing):
+        # re-label menu item and button, re-set callback
+        c = self.OnPlay if playing is None else self.OnPause
+        p = 'Pause' if playing else 'Play'
+        self.fileMenu.entryconfig(self.playIndex, label=p, command=c)
+        self.playButton.config(text=p, command=c)
+        # including macOS shortcut callback kludge
+        _Tk_Menu._shortcuts['p'] = c
+
+    def _Play(self, video):
+        # helper for OnOpen and OnPlay
+        if isfile(video):  # Creation
+            m = self.Instance.media_new(str(video))  # Path, unicode
+            self.player.set_media(m)
             self.parent.title("tkVLCplayer - %s" % (basename(video),))
 
             # set the window id where to render VLC's video output
-            h = self.GetHandle()
+            h = self.videopanel.winfo_id()  # .winfo_visualid()?
             if _isWindows:
                 self.player.set_hwnd(h)
             elif _isMacOS:
@@ -224,172 +296,111 @@ class Player(Tk.Frame):
             # FIXME: this should be made cross-platform
             self.OnPlay()
 
-            # set the volume slider to the current volume
-            #self.volslider.SetValue(self.player.audio_get_volume() / 2)
-            self.volslider.set(self.player.audio_get_volume())
-
-    def OnPlay(self):
-        """Toggle the status to Play/Pause.
-        If no file is loaded, open the dialog window.
+    def OnPause(self, *unused):
+        """Toggle between Pause and Play.
         """
-        # check if there is a file to play, otherwise open a
-        # Tk.FileDialog to select a file
+        if self.player.get_media():
+            self._Pause(not self.player.is_playing())
+            self.player.pause()  # toggles
+
+    def OnPlay(self, *unused):
+        """Play video, if none is loaded, open the dialog window.
+        """
+        # if there's no video to play or playing,
+        # open a Tk.FileDialog to select a file
         if not self.player.get_media():
-            self.OnOpen()
+            if self.video:
+                self._Play(expanduser(self.video))
+                self.video = ''
+            else:
+                self.OnOpen()
+        # Try to play, if this fails display an error message
+        elif self.player.play():  # == -1
+            self.showError("Unable to play a video.")
         else:
-            # Try to launch the media, if this fails display an error message
-            if self.player.play() == -1:
-                self.errorDialog("Unable to play.")
+            self._Pause(True)
+            # set volume slider to audio level
+            vol = self.player.audio_get_volume()
+            if vol > 0:
+                self.volVar.set(vol)
+                self.volSlider.set(vol)
+            # adjust window to video aspect ratio
+            # w, h = self.player.video_get_size()
+            # if h > 0 and w > 0:  # often (0, 0)
+            #     self.parent.geometry("%sx%s+0+0" % (w, h))
 
-    def GetHandle(self):
-        return self.videopanel.winfo_id()
-
-    #def OnPause(self, evt):
-    def OnPause(self):
-        """Pause the player.
+    def OnStop(self, *unused):
+        """Stop the player, resets media.
         """
-        self.player.pause()
+        if self.player:
+            self.player.stop()
+            self._Pause(None)
+            # reset the time slider
+            self.timeSlider.set(0)
 
-    def OnStop(self):
-        """Stop the player.
+    def OnTick(self):
+        """Timer tick, update the time slider to the video time.
         """
-        self.player.stop()
-        # reset the time slider
-        self.timeslider.set(0)
+        if self.player:
+            # since the self.player.get_length may change while
+            # playing, re-set the timeSlider to the correct range
+            t = self.player.get_length() * 1e-3  # to seconds
+            if t > 0:
+                self.timeSlider.config(to=t)
 
-    def OnTimer(self):
-        """Update the time slider according to the current movie time.
+                t = self.player.get_time() * 1e-3  # to seconds
+                # don't change slider while user is messing with it
+                if t > 0 and time.time() > (self.timeSliderUpdate + 2):
+                    self.timeSlider.set(t)
+                    self.timeSliderLast = int(self.timeVar.get())
+        # start the 1 second timer again
+        self.parent.after(1000, self.OnTick)
+
+    def OnTime(self, *unused):
+        if self.player:
+            t = self.timeVar.get()
+            if self.timeSliderLast != int(t):
+                # this is a hack. The timer updates the time slider.
+                # This change causes this rtn (the 'slider has changed' rtn)
+                # to be invoked.  I can't tell the difference between when
+                # the user has manually moved the slider and when the timer
+                # changed the slider.  But when the user moves the slider
+                # tkinter only notifies this rtn about once per second and
+                # when the slider has quit moving.
+                # Also, the tkinter notification value has no fractional
+                # seconds.  The timer update rtn saves off the last update
+                # value (rounded to integer seconds) in timeSliderLast if
+                # the notification time (sval) is the same as the last saved
+                # time timeSliderLast then we know that this notification is
+                # due to the timer changing the slider.  Otherwise the
+                # notification is due to the user changing the slider.  If
+                # the user is changing the slider then I have the timer
+                # routine wait for at least 2 seconds before it starts
+                # updating the slider again (so the timer doesn't start
+                # fighting with the user).
+                self.player.set_time(int(t * 1e3))  # milliseconds
+                self.timeSliderUpdate = time.time()
+
+    def OnVolume(self, *unused):
+        """Volume slider changed, adjust the audio volume.
         """
-        if self.player is None:
-            return
-        # since the self.player.get_length can change while playing,
-        # re-set the timeslider to the correct range.
-        length = self.player.get_length()
-        dbl = length * 0.001
-        self.timeslider.config(to=dbl)
+        vol = min(self.volVar.get(), 100)
+        v_M = "%d%s" % (vol, " (Muted)" if self.muted else '')
+        self.volSlider.config(label="Volume " + v_M)
+        if self.player and vol > 0:  # and not self.muted:
+            # .audio_set_volume returns 0 if success, -1 otherwise,
+            # for example if the player doesn't haven any media
+            if self.player.audio_set_volume(vol):  # and self.player.get_media():
+                self.showError("Failed to set the volume: %s." % (v_M,))
 
-        # update the time on the slider
-        tyme = self.player.get_time()
-        if tyme == -1:
-            tyme = 0
-        dbl = tyme * 0.001
-        self.timeslider_last_val = ("%.0f" % dbl) + ".0"
-        # don't want to programatically change slider while user is messing with it.
-        # wait 2 seconds after user lets go of slider
-        if time.time() > (self.timeslider_last_update + 2.0):
-            self.timeslider.set(dbl)
-
-    def scale_sel(self, evt):
-        if self.player is None:
-            return
-        nval = self.scale_var.get()
-        sval = str(nval)
-        if self.timeslider_last_val != sval:
-            # this is a hack. The timer updates the time slider.
-            # This change causes this rtn (the 'slider has changed' rtn) to be invoked.
-            # I can't tell the difference between when the user has manually moved the slider and when
-            # the timer changed the slider. But when the user moves the slider tkinter only notifies
-            # this rtn about once per second and when the slider has quit moving.
-            # Also, the tkinter notification value has no fractional seconds.
-            # The timer update rtn saves off the last update value (rounded to integer seconds) in timeslider_last_val
-            # if the notification time (sval) is the same as the last saved time timeslider_last_val then
-            # we know that this notification is due to the timer changing the slider.
-            # otherwise the notification is due to the user changing the slider.
-            # if the user is changing the slider then I have the timer routine wait for at least
-            # 2 seconds before it starts updating the slider again (so the timer doesn't start fighting with the
-            # user)
-            self.timeslider_last_update = time.time()
-            mval = "%.0f" % (nval * 1000)
-            self.player.set_time(int(mval))  # expects milliseconds
-
-    def volume_sel(self, evt):
-        if self.player is None:
-            return
-        volume = self.volume_var.get()
-        if volume > 100:
-            volume = 100
-        if self.player.audio_set_volume(volume) == -1:
-            self.errorDialog("Failed to set volume")
-
-    def OnToggleVolume(self, evt):
-        """Mute/Unmute according to the audio button.
-        """
-        is_mute = self.player.audio_get_mute()
-
-        self.player.audio_set_mute(not is_mute)
-        # update the volume slider;
-        # since vlc volume range is in [0, 200],
-        # and our volume slider has range [0, 100], just divide by 2.
-        self.volume_var.set(self.player.audio_get_volume())
-
-    def OnSetVolume(self):
-        """Set the volume according to the volume sider.
-        """
-        volume = self.volume_var.get()
-        # vlc.MediaPlayer.audio_set_volume returns 0 if success, -1 otherwise
-        if volume > 100:
-            volume = 100
-        if self.player.audio_set_volume(volume) == -1:
-            self.errorDialog("Failed to set volume")
-
-    def errorDialog(self, errormessage):
+    def showError(self, message):
         """Display a simple error dialog.
         """
-        Tk.tkMessageBox.showerror(self, 'Error', errormessage)
-
-
-def Tk_get_root():
-    if not hasattr(Tk_get_root, "root"):  # (1)
-        Tk_get_root.root= Tk.Tk()  # initialization call is inside the function
-    return Tk_get_root.root
-
-
-def _quit():
-    # print("_quit: bye")
-    root = Tk_get_root()
-    root.quit()     # stops mainloop
-    root.destroy()  # this is necessary on Windows to prevent
-                    # Fatal Python Error: PyEval_RestoreThread: NULL tstate
-    os._exit(1)
+        self.OnStop()
+        showerror(self.parent.title(), message)
 
 
 if __name__ == "__main__":
-
-    # XXX vlc.py should export print_python
-    def print_python():
-        """Print Python and O/S version"""
-        from platform import architecture, mac_ver, uname, win32_ver
-        if 'intelpython' in sys.executable:
-            t = 'Intel-'
-        # elif 'PyPy ' in sys.version:
-        #     t = 'PyPy-'
-        else:
-            t = ''
-        t = '%sPython: %s (%s)' % (t, sys.version.split()[0], architecture()[0])
-        if win32_ver()[0]:
-            t = t, 'Windows', win32_ver()[0]
-        elif mac_ver()[0]:
-            t = t, ('iOS' if sys.platform == 'ios' else 'macOS'), mac_ver()[0]
-        else:
-            try:
-                import distro  # <http://GitHub.com/nir0s/distro>
-                t = t, vlc.bytes_to_str(distro.name()), vlc.bytes_to_str(distro.version())
-            except ImportError:
-                t = (t,) + uname()[0:3:2]
-        print(' '.join(t))
-
-    # XXX vlc.py should export print_version
-    def print_version():
-        """Print version of vlc.py and of libvlc"""
-        try:
-            print('%s: %s (%s)' % (basename(vlc.__file__), vlc.__version__, vlc.build_date))
-            print('LibVLC version: %s (%#x)' % (vlc.bytes_to_str(vlc.libvlc_get_version()), vlc.libvlc_hex_version()))
-            print('LibVLC compiler: %s' % vlc.bytes_to_str(vlc.libvlc_get_compiler()))
-            if vlc.plugin_path:
-                print('Plugin path: %s' % vlc.plugin_path)
-        except Exception:
-            print('Error: %s' % sys.exc_info()[1])
-
 
     _video = ''
 
@@ -398,7 +409,7 @@ if __name__ == "__main__":
         if arg.lower() in ('-v', '--version'):
             # show all versions, sample output on macOS:
             # % python3 ./tkvlc.py -v
-            # tkvlc.py: 2019.07.24 (tkinter 8.6 /Library/Frameworks/Python.framework/Versions/3.7/lib/libtk8.6.dylib)
+            # tkvlc.py: 2019.07.28 (tkinter 8.6 /Library/Frameworks/Python.framework/Versions/3.7/lib/libtk8.6.dylib)
             # vlc.py: 3.0.6109 (Sun Mar 31 20:14:16 2019 3.0.6)
             # LibVLC version: 3.0.6 Vetinari (0x3000600)
             # LibVLC compiler: clang: warning: argument unused during compilation: '-mmacosx-version-min=10.7' [-Wunused-command-line-argument]
@@ -408,8 +419,11 @@ if __name__ == "__main__":
             # Print version of this vlc.py and of the libvlc
             print('%s: %s (%s %s %s)' % (basename(__file__), __version__,
                                          Tk.__name__, Tk.TkVersion, libtk))
-            print_version()
-            print_python()
+            try:
+                vlc.print_version()
+                vlc.print_python()
+            except AttributeError:
+                pass
             sys.exit(0)
 
         elif arg.startswith('-'):
@@ -422,10 +436,8 @@ if __name__ == "__main__":
                 print('%s error: no such file: %r' % (sys.argv[0], arg))
                 sys.exit(1)
 
-    # Create a Tk.App(), which handles the windowing system event loop
-    root = Tk_get_root()
-    root.protocol("WM_DELETE_WINDOW", _quit)
-
+    # Create a Tk.App() to handle the windowing event loop
+    root = Tk.Tk()
     player = Player(root, video=_video)
-    # show the player window centred and run the application
+    root.protocol("WM_DELETE_WINDOW", player.OnClose)  # XXX unnecessary (on macOS)
     root.mainloop()


### PR DESCRIPTION
The shortcut keys in menu items now work on macOS, with a little cleaner workaround for the missing and/or failing modifier key binding. 

Also, the `Play` and `Mute` menu and button labels now toggle between `Play` and `Pause` respectively `Mute` and `Unmute`.

The timer class has been replaced by a one-line call to Tk's `after` method.

The `Quit` menu, the Q- and W-shortcut keys and the error dialog are all working properly now.

Unresolved remains the overwriting of the buttons and sliders by the video.  The buttons do work when clicking near the bottom of the video.

Un/mute is working, but may be unreliable (a VLC issue, see the `libvlc_audio_set_mute.__doc__`).

Like before, _only tested on macOS 10.13.6_ with Tk 8.6.9 and `vlc.py` 3.0.6109 using Python 3.7.4 64-bit.  If you have a Windows and/or *nix system with Python 3.4+ , please run this one.

Some screen shots follow.

![tkvlc190728a](https://user-images.githubusercontent.com/22154337/62013226-96b48a80-b15d-11e9-8d6a-c9ab27ff5f0e.jpg)

![tkvlc190728b](https://user-images.githubusercontent.com/22154337/62013227-9916e480-b15d-11e9-87ff-4d2effb47543.jpg)
