### PR TITLE
Improve parameters parsing and fix callbacks

### DIFF
--- a/generator/generate.py
+++ b/generator/generate.py
@@ -427,12 +427,15 @@ class Par(object):
         """
         if self.name in out:
             f = Flag.Out  # @param [OUT]
-        else:
+        elif not self.constness[0]:
             f = {'int*':      Flag.Out,
                  'unsigned*': Flag.Out,
                  'unsigned char*': Flag.Out,
                  'libvlc_media_track_info_t**': Flag.Out,
                 }.get(self.type, Flag.In)  # default
+        else:
+            f = Flag.In
+
         if default is None:
             return f,  # 1-tuple
         else:  # see ctypes 15.16.2.4 Function prototypes

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -156,6 +156,7 @@ callback_type_re = re.compile(r'^typedef\s+\w+(\s*\*)?\s*\(\s*\*')
 callback_re  = re.compile(r'typedef\s+\*?(\w+\s*\*?)\s*\(\s*\*\s*(\w+)\s*\)\s*\((.+)\);')
 struct_type_re = re.compile(r'^typedef\s+struct\s*(\S+)\s*$')
 struct_re    = re.compile(r'typedef\s+(struct)\s*(\S+)?\s*\{\s*(.+)\s*\}\s*(?:\S+)?\s*;')
+func_pointer_re = re.compile(r'(\(?[^\(]+)\s+\((\*\s*\S*)\)(\(.*\))') # (ret_type, *pointer_name, ([params]))
 typedef_re   = re.compile(r'^typedef\s+(?:struct\s+)?(\S+)\s+(\S+);')
 forward_re   = re.compile(r'.+\(\s*(.+?)\s*\)(\s*\S+)')
 libvlc_re    = re.compile(r'libvlc_[a-z_]+')
@@ -713,8 +714,7 @@ class Parser(object):
             param_raw = m.group(1) + m.group(2)
 
         # is this a function pointer?
-        RE_FUNC_POINTER = r'\(.+\)\s*\(.+\)'
-        if re.search(RE_FUNC_POINTER, param_raw):
+        if func_pointer_re.search(param_raw):
             return None
 
         # is this parameter a pointer?

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -390,6 +390,14 @@ class Par(object):
     """C function parameter.
     """
     def __init__(self, name, type, constness):
+        """
+        constness:  a list of bools where each index refers to the constness
+                    of that level of indirection.
+                        [0] no indirection: is the value const?
+                        [1] pointer to value: is this pointer const?
+                        [2] pointer to pointer: is this pointer const?
+                        ... rare to see more than two levels of indirection
+        """
         self.name = name
         self.type = type  # C type
         self.constness = constness

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -758,15 +758,12 @@ class Parser(object):
             # normalize spaces
             param_raw = re.sub('\s+', ' ', param_raw)
 
-            try:
-                split_value = param_raw.split(' ')
-                if len(split_value) > 1:
-                    param_name = split_value[-1]
-                    param_type = ' '.join(split_value[:-1])
-                else:
-                    param_type = split_value[0]
-                    param_name = ''
-            except:
+            split_value = param_raw.split(' ')
+            if len(split_value) > 1:
+                param_name = split_value[-1]
+                param_type = ' '.join(split_value[:-1])
+            else:
+                param_type = split_value[0]
                 param_name = ''
 
             param_constness = [False]

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -422,6 +422,7 @@ class Par(object):
         else:
             f = {'int*':      Flag.Out,
                  'unsigned*': Flag.Out,
+                 'unsigned char*': Flag.Out,
                  'libvlc_media_track_info_t**': Flag.Out,
                 }.get(self.type, Flag.In)  # default
         if default is None:
@@ -1048,6 +1049,7 @@ class PythonGenerator(_Generator):
 
     type2class_out = {
         'char**':    'ctypes.POINTER(ctypes.c_char_p)',
+        'unsigned char*':    'ctypes.POINTER(ctypes.c_char)',
     }
 
     # Python classes, i.e. classes for which we want to

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -395,7 +395,7 @@ class Par(object):
         self.constness = constness
 
     def __repr__(self):
-        return "%s (%s)" % (self.name, self.type)
+        return "%s (%s) %s" % (self.name, self.type, self.constness)
 
     def dump(self, out=()):  # for debug
         if self.name in out:

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -699,6 +699,11 @@ class Parser(object):
             m = forward_re.match(param_raw)
             param_raw = m.group(1) + m.group(2)
 
+        # is this a function pointer?
+        RE_FUNC_POINTER = r'\(.+\)\s*\(.+\)'
+        if re.search(RE_FUNC_POINTER, param_raw):
+            return None
+
         # is this parameter a pointer?
         split_pointer = param_raw.split('*')
         if len(split_pointer) > 1:

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -389,9 +389,10 @@ class Func(_Source):
 class Par(object):
     """C function parameter.
     """
-    def __init__(self, name, type):
+    def __init__(self, name, type, constness):
         self.name = name
         self.type = type  # C type
+        self.constness = constness
 
     def __repr__(self):
         return "%s (%s)" % (self.name, self.type)
@@ -728,6 +729,8 @@ class Parser(object):
             # ASSUMPTION
             # just indirection level 0 and 1 can be const
             for deref_level_constness in constness[2:]: assert(not deref_level_constness)
+
+            param_constness = constness[:2]
         # ... or is it a simple variable?
         else:
             # WARNING: workaround for "union { struct {"
@@ -742,7 +745,7 @@ class Parser(object):
 
             # normalize spaces
             param_raw = re.sub('\s+', ' ', param_raw)
-            # TODO remove struct and const
+
             try:
                 split_value = param_raw.split(' ')
                 if len(split_value) > 1:
@@ -754,7 +757,9 @@ class Parser(object):
             except:
                 param_name = ''
 
-        return Par(param_name.strip(), param_type.strip())
+            param_constness = [False]
+
+        return Par(param_name.strip(), param_type.strip(), param_constness)
 
     def parse_version(self, h_files):
         """Get the libvlc version from the C header files:

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -707,13 +707,27 @@ class Parser(object):
         # is this parameter a pointer?
         split_pointer = param_raw.split('*')
         if len(split_pointer) > 1:
+            param_type = split_pointer[0]
             param_name = split_pointer[-1]
-            # TODO extract constness
+            param_deref_levels = len(split_pointer) - 1
+
+            # it is a pointer, so it should have at least 1 level of indirection
+            assert(param_deref_levels > 0)
+
+            # PARAM TYPE
             param_type = split_pointer[0].replace('const', '').strip()
             # remove the struct keyword, this information is currently not used
             param_type = param_type.replace('struct ', '').strip()
 
-            param_type += '*' * (len(split_pointer) - 1 )
+            # POINTER SEMANTIC
+            # add back the information of how many dereference levels there are
+            param_type += '*' * param_deref_levels
+
+            constness = ['const' in deref_level for deref_level in split_pointer]
+
+            # ASSUMPTION
+            # just indirection level 0 and 1 can be const
+            for deref_level_constness in constness[2:]: assert(not deref_level_constness)
         # ... or is it a simple variable?
         else:
             # WARNING: workaround for "union { struct {"


### PR DESCRIPTION
Close #117 

As per discussion in the issue, I tried to improve a bit the parser for parameters. It is far from being perfect.

The new method should is not regex based, it should be able to detect all types and pointers with related constness. The constness information is stored inside `Par` as a list of bools, intrinsically giving two information:
- it is a value (`len==0`), a pointer (`len==1`) or a pointer to pointer (`len==2`)
- constness for each existing level of indirection

e.g.
- `const int *` -> `[True, False]`
- `const int * const` -> `[True, True]`
- `int * const` -> `[False, True]`