### PR TITLE
Fix dll not found on Python 3.8+

### DIFF
--- a/generator/templates/header.py
+++ b/generator/templates/header.py
@@ -160,11 +160,11 @@ def find_lib():
                 p = os.getcwd()
                 os.chdir(plugin_path)
                  # if chdir failed, this will raise an exception
-                dll = ctypes.CDLL(libname)
+                dll = ctypes.CDLL('.\\' + libname)
                  # restore cwd after dll has been loaded
                 os.chdir(p)
             else:  # may fail
-                dll = ctypes.CDLL(libname)
+                dll = ctypes.CDLL('.\\' + libname)
         else:
             plugin_path = os.path.dirname(p)
             dll = ctypes.CDLL(p)


### PR DESCRIPTION
Closes #118 

Since Python 3.8, dll files cannot be loaded anymore from name only.

From https://docs.python.org/3/whatsnew/3.8.html :
> DLL dependencies for extension modules and DLLs loaded with ctypes on Windows are now resolved more securely. Only the system paths, the directory containing the DLL or PYD file, and directories added with add_dll_directory() are searched for load-time dependencies. Specifically, PATH and the current working directory are no longer used, and modifications to these will no longer have any effect on normal DLL resolution.

Replacing `foo.dll` by a path `.\\foo.dll` is enough to fix this issue.