### PR TITLE
TopLevel window to hold the buttons panel.

### DIFF
--- a/examples/tkvlc.py
+++ b/examples/tkvlc.py
@@ -266,7 +266,7 @@ class Player(Tk.Frame):
         panel_y = self.parent.winfo_y() + video_height + 23 # 23 seems to put the panel just below our video.
         panel_height = self.buttons_panel.winfo_height()
         panel_width = self.parent.winfo_width()
-        self.buttons_panel.geometry(f'{panel_width}x{panel_height}+{panel_x}+{panel_y}')
+        self.buttons_panel.geometry("%sx%s+%s+%s" % (panel_width, panel_height, panel_x, panel_y))
 
     def OnConfigure(self, *unused):
         """Some widget configuration changed.

--- a/examples/tkvlc.py
+++ b/examples/tkvlc.py
@@ -218,8 +218,8 @@ class Player(Tk.Frame):
         self.volSlider = Tk.Scale(buttons, variable=self.volVar, command=self.OnVolume,
                                   from_=0, to=100, orient=Tk.HORIZONTAL, length=200,
                                   showvalue=0, label='Volume')
-        self.volSlider.pack(side=Tk.LEFT)
-        buttons.pack(side=Tk.BOTTOM)
+        self.volSlider.pack(side=Tk.RIGHT)
+        buttons.pack(side=Tk.BOTTOM, fill=Tk.X)
 
 
         # panel to hold player time slider
@@ -248,7 +248,7 @@ class Player(Tk.Frame):
         self.buttons_panel.overrideredirect(True)
 
         # Estetic, to keep our video panel at least as wide as our buttons panel.
-        self.parent.minsize(width=self.buttons_panel.winfo_width(), height=0)
+        self.parent.minsize(width=502, height=0)
 
         self.OnTick()  # set the timer up
 
@@ -264,7 +264,9 @@ class Player(Tk.Frame):
         video_height = self.parent.winfo_height()
         panel_x = self.parent.winfo_x()
         panel_y = self.parent.winfo_y() + video_height + 23 # 23 seems to put the panel just below our video.
-        self.buttons_panel.geometry(f'+{panel_x}+{panel_y}')
+        panel_height = self.buttons_panel.winfo_height()
+        panel_width = self.parent.winfo_width()
+        self.buttons_panel.geometry(f'{panel_width}x{panel_height}+{panel_x}+{panel_y}')
 
     def OnConfigure(self, *unused):
         """Some widget configuration changed.

--- a/examples/tkvlc.py
+++ b/examples/tkvlc.py
@@ -273,7 +273,10 @@ class Player(Tk.Frame):
         """
         # <https://www.Tcl.Tk/man/tcl8.6/TkCmd/bind.htm#M12>
         self._geometry = ''  # force .OnResize in .OnTick, recursive?
-        self._AnchorButtonsPanel()
+
+        # Only tested on MacOS so far. Enable for other OS after verified tests.
+        if _isMacOS:
+            self._AnchorButtonsPanel()
 
     def OnFullScreen(self, *unused):
         """Toggle full screen, macOS only.

--- a/examples/tkvlc.py
+++ b/examples/tkvlc.py
@@ -259,7 +259,6 @@ class Player(Tk.Frame):
         self.parent.quit()  # stops mainloop
         self.parent.destroy()  # this is necessary on Windows to avoid
         # ... Fatal Python Error: PyEval_RestoreThread: NULL tstate
-        sys.exit(0)
 
     def _AnchorButtonsPanel(self):
         video_height = self.parent.winfo_height()


### PR DESCRIPTION
Workaround as MacOS draws the video over the whole app including the buttons. Dividing the app into two seperate windows makes the app work as intended even on MacOS as the buttons stays visible.

Only tested on MacOS Mojave, version 10.14.6.
The _AnchorButtonsPanel is mainly for esthetic purposes, can be omitted.