### PR TITLE
fix return types for callbacks

### DIFF
--- a/generator/generate.py
+++ b/generator/generate.py
@@ -604,7 +604,7 @@ class Parser(object):
 
             pars = [Par.parse_param(p) for p in paramlist_re.split(pars)]
 
-            yield Func(name, type_.replace(' ', '') + '*', pars, docs,
+            yield Func(name, type_.replace(' ', ''), pars, docs,
                        file_=self.h_file, line=line)
 
     def parse_enums(self):
@@ -1241,10 +1241,7 @@ class _Enum(ctypes.c_uint):
             name = self.class4(f.name)  #PYCHOK flake
 
             # return value and arg classes
-            # Note: The f.type == 'void**' is a hack to generate a
-            # valid ctypes signature, specifically for the
-            # libvlc_video_lock_cb callback. It should be fixed in a better way (more generic)
-            types = ', '.join([self.class4('void*' if f.type == 'void**' else f.type)] +  #PYCHOK flake
+            types = ', '.join([self.class4(f.type)] +  #PYCHOK flake
                               [self.class4(p.type, p.flags(f.out)[0]) for p in f.pars])
 
             # xformed doc string with first @param


### PR DESCRIPTION
This PR proposes to fix a problem with return types for callbacks.

After commit c01a4f6523a1e03919ed3a34d3d0f231b010dab1, a problem arose with callbacks return types (in particular I found problem with `MediaOpenCb`, `MediaReadCb`, ...).

I'm missing the reason why all callback return types were forcefully converted to pointers (which is the main point of this PR).

Looking forward for any feedback.