### PR TITLE
mrJean1 len_args

### DIFF
--- a/generator/templates/header.py
+++ b/generator/templates/header.py
@@ -47,8 +47,7 @@ import sys
 import functools
 
 # Used by EventManager in override.py
-from inspect import getargspec, signature
-
+import inspect as _inspect
 import logging
 logger = logging.getLogger(__name__)
 
@@ -80,6 +79,12 @@ if sys.version_info[0] > 2:
             return b.decode(DEFAULT_ENCODING)
         else:
             return b
+
+    def len_args(func):
+        """Return number of positional arguments.
+        """
+        return len(_inspect.signature(func).parameters)
+
 else:
     str = str
     unicode = unicode
@@ -101,6 +106,11 @@ else:
             return unicode(b, DEFAULT_ENCODING)
         else:
             return b
+
+    def len_args(func):
+        """Return number of positional arguments.
+        """
+        return len(_inspect.getargspec(func).args)
 
 # Internal guard to prevent internal classes to be directly
 # instanciated.

--- a/generator/templates/override.py
+++ b/generator/templates/override.py
@@ -102,11 +102,9 @@ class Instance:
         """
         # API 3 vs 4: libvlc_media_list_new does not take any
         # parameter as input anymore.
-        if len(signature(libvlc_media_list_new).parameters) == 1:
-            # API <= 3
+        if len_args(libvlc_media_list_new) == 1:  # API <= 3
             l = libvlc_media_list_new(self)
-        else:
-            # API >= 4
+        else:  # API >= 4
             l = libvlc_media_list_new()
         # We should take the lock, but since we did not leak the
         # reference, nobody else can access it.

--- a/generator/templates/override.py
+++ b/generator/templates/override.py
@@ -477,7 +477,7 @@ class EventManager:
         if not hasattr(callback, '__call__'):  # callable()
             raise VLCException("%s required: %r" % ('callable', callback))
          # check that the callback expects arguments
-        if not any(getargspec(callback)[:2]):  # list(...)
+        if len_args(callback) < 1:  # list(...)
             raise VLCException("%s required: %r" % ('argument', callback))
 
         if self._callback_handler is None:


### PR DESCRIPTION
Proposing a new, internal function `len_args` to get the number of positional arguments of a callable.

This is to replace `inspect.getargspec` deprecated in Python 3 and `inspect.signature` not available in Python 2.