### PR TITLE
generator: fix first function parse in header

### DIFF
--- a/generator/generate.py
+++ b/generator/generate.py
@@ -166,7 +166,7 @@ decllist_re  = re.compile(r'\s*;\s*')
 paramlist_re = re.compile(r'\s*,\s*')
 version_re   = re.compile(r'vlc[\-]\d+[.]\d+[.]\d+.*')
 LIBVLC_V_re  = re.compile(r'\s*#\s*define\s+LIBVLC_VERSION_([A-Z]+)\s+\(*(\d+)\)*')
-define_re    = re.compile(r'^\s*#\s*define\s+\w+\s+.+?$')
+define_re    = re.compile(r'^\s*#\s*define\s+\w+\s+.*?$')
 
 def endot(text):
     """Terminate string with a period.


### PR DESCRIPTION
The "#define" regex does not seem to match empty value #define. For example, the "# define LIBVLC_API" line is not considered as define sequence. One of the consequence is the first function declaration detected is considered as part of a multiline block, and thus ignored.

Accepting "#define XXX" sequences as well as "#define XXX yyy" seems to fix the issue (first function declared in header missing).