### PR TITLE
Enhancements for Windows and macOS.

### DIFF
--- a/examples/tkvlc.py
+++ b/examples/tkvlc.py
@@ -26,29 +26,71 @@ Date: 23-09-2015
 
 # Tested with VLC 3.0.16, 3.0.12, 3.0.11, 3.0.10, 3.0.8 and 3.0.6 with
 # the compatible vlc.py Python-VLC binding, Python 3.11.0, 3.10.0, 3.9.0
-# and 3.7.4 with tkinter/Tk 8.6.9 on macOS 13.0 (amd64 M1), 11.6.1 (10.16
+# and 3.7.4 with tkinter/Tk 8.6.9 on macOS 13.0.1 (amd64 M1), 11.6.1 (10.16
 # amd64 M1), 11.0.1 (10.16 x86-64) and 10.13.6 only.
-__version__ = '22.11.11'  # mrJean1 at Gmail
+__version__ = '22.12.12'  # mrJean1 at Gmail
 
 import sys
 try:  # Python 3.4+ only
     import tkinter as Tk
-    from tkinter import ttk  # PYCHOK ttk = Tk.ttk
+    from tkinter import TclError, ttk  # PYCHOK ttk = Tk.ttk
     from tkinter.filedialog import askopenfilename
     from tkinter.messagebox import showerror
-    from pathlib import Path
 except ImportError:
     sys.exit('%s requires Python 3.4 or later' % (sys.argv[0],))
-    # import Tkinter as Tk
+    # import Tkinter as Tk; ttk = Tk
 import os
 import time
 import vlc
 
-_dragging  = False  # use -dragging option
-
 _isMacOS   = sys.platform.startswith('darwin')
-_isWindows = sys.platform.startswith('win')
 _isLinux   = sys.platform.startswith('linux')
+_isWindows = sys.platform.startswith('win')
+
+_ANCHORED    = 'Anchored'
+_BANNER_H    =  32 if _isMacOS else 64
+_BUTTONS     = 'Buttons'
+_DISABLED    = (      Tk.DISABLED,)
+_ENABLED     = ('!' + Tk.DISABLED,)
+_FULL_OFF    = 'Full Off'
+_FULL_SCREEN = 'Full Screen'
+# see _Tk_Menu.add_item and .bind_shortcut below
+# <https://www.Tcl.Tk/man/tcl8.6/TkCmd/keysyms.html>
+_KEY_SYMBOL  = {'~': 'asciitilde',  '`': 'grave',
+                '!': 'exclam',      '@': 'at',
+                '#': 'numbersign',  '$': 'dollar',
+                '%': 'percent',     '^': 'asciicirum',
+                '&': 'ampersand',   '*': 'asterisk',
+                '(': 'parenleft',   ')': 'parenright',
+                '_': 'underscore',  '-': 'minus',
+                '+': 'plus',        '=': 'equal',
+                '{': 'braceleft',   '}': 'braceright',
+                '[': 'bracketleft', ']': 'bracketright',
+                '|': 'bar',        '\\': 'backslash',
+                ':': 'colon',       ';': 'semicolon',
+                '"': 'quotedbl',    "'": 'apostrophe',
+                '<': 'less',        '>': 'greater',
+                ',': 'comma',       '.': 'period',
+                '?': 'question',    '/': 'slash',
+                ' ': 'space',      '\b': 'BackSpace',
+               '\n': 'KP_Enter',   '\r': 'Return',
+               '\f': 'Next',       '\v': 'Prior',
+               '\t': 'Tab'}  # '\a': 'space'?
+# see definition of specialAccelerators in <https://
+# GitHub.com/tcltk/tk/blob/main/macosx/tkMacOSXMenu.c>
+_MAC_ACCEL   = {' ': 'Space',       '\b': 'Backspace',
+               '\n': 'Enter',       '\r': 'Return',
+               '\f': 'PageDown',    '\v': 'PageUp',
+               '\t': 'Tab',  # 'BackTab', 'Eject'?
+             'Next': 'PageDown', 'Prior': 'PageUp'}
+_MIN_W       =  420
+_OPACITY     = 'Opacity %s%%'
+_TAB_X       =  32
+_T_CONFIGURE =  Tk.EventType.Configure
+_TICK_MS     =  100  # millisecs per time tick
+_UN_ANCHORED = 'Un-' + _ANCHORED
+_VOLUME      = 'Volume'
+_WIGGLE_F    =  0.75
 
 _TKVLC_LIBTK_PATH = 'TKVLC_LIBTK_PATH'
 
@@ -62,7 +104,7 @@ if _isMacOS:  # MCCABE 14
     # Python 3+ or one matching the version of tkinter
 
     # Homebrew-built Python, Tcl/Tk, etc. are installed in
-    # different places, usually something like /usr/- or
+    # different places, usually something like (/usr/- or)
     # /opt/local/Cellar/tcl-tk/8.6.11_1/lib/libtk8.6.dylib,
     # found by command line `find /opt -name libtk8.6.dylib`
 
@@ -109,7 +151,7 @@ if _isMacOS:  # MCCABE 14
         # C signature: void *_GetNSView(void *drawable) to get
         # the Cocoa/Obj-C NSWindow.contentView attribute, the
         # drawable NSView object of the (drawable) NSWindow
-        _GetNSView.restype = c_void_p
+        _GetNSView.restype  =  c_void_p
         _GetNSView.argtypes = (c_void_p,)
 
     except (NameError, OSError) as x:  # lib, image or symbol not found
@@ -119,524 +161,1084 @@ if _isMacOS:  # MCCABE 14
             return None
 
     del cdll, c_void_p, env, _find
-    C_Key = 'Command-'  # shortcut key modifier
+    Cmd_ = 'Command+'  # 'Meta_L' shortcut key modifier
 
-else:  # *nix, Xwindows and Windows, UNTESTED
-
+else:  # Windows OK, untested *nix, Xwindows
     libtk = 'N/A'
-    C_Key = 'Control-'  # shortcut key modifier
+    Cmd_  = 'Ctrl+'  # shortcut key modifier, Control!
+
+
+def _frontmost(p, *ontop):
+    # move panel to the front
+    t = p.attributes('-topmost')
+    if ontop:
+        m = bool(ontop[0])
+        p.attributes('-topmost', m)
+        p.update_idletasks()
+        if m:
+            p.attributes('-topmost', False)
+            try:  # no Toplevel.force_focus
+                p.force_focus()
+            except AttributeError:
+                pass
+    return bool(t)
+
+
+def _full_screen(p, *full):
+    # get/set a panel full- or off-screen
+    f = p.attributes('-fullscreen')  # or .wm_attributes
+    if full:
+        p.attributes('-fullscreen', bool(full[0]))
+        p.update_idletasks()
+    return f
+
+
+def _geometry(p, g_w, *h_x_y):
+    # set a panel geometry to C{g} or C{w, h, x, y}.
+    g = _geometrys(g_w, *h_x_y) if h_x_y else g_w
+    p.geometry(g)
+    return _geometry1(p)  # update geometry
+
+
+def _geometrys(w, *h_x_y):
+    # get a geometry str "wxh+x+y"
+    t = '+'.join(map(str, h_x_y))
+    g = 'x'.join((str(w), t))
+    return g
+
+
+def _geometry1(p):
+    # get a panel geometry as C{str}
+    p.update_idletasks()
+    return p.geometry()
+
+
+def _geometry5(p):
+    # get a panel geometry as 5-tuple of C{str}s
+    g = _geometry1(p)  # '+-x' means absolute -x
+    # t = g.replace('+-', '-').replace('-', '+-')
+    z, x, y = g.split('+')
+    w, h = z.split('x')
+    return g, w, h, x, y
+
+
+def _hms(tensecs, secs=''):
+    s = tensecs * 0.1
+    if s < 60:
+        t = '%3.1f%s' % (s, secs)
+    else:
+        m, s = divmod(s, 60)
+        if m < 60:
+            t = '%d:%04.1f' % (int(m), s)
+        else:
+            h, m = divmod(m, 60)
+            t = '%d:%02d:%04.1f' % (int(h), int(m), s)
+    return t
+
+
+def _underline2(c, label='', underline=-1, **cfg):
+    # update cfg with C{underline=index} or remove C{underline=.}
+    u = label.find(c) if c and label else underline
+    if u >= 0:
+        cfg.update(underline=u)
+    else:  # no underlining
+        c = ''
+    cfg.update(label=label)
+    return c, cfg
+
+
+class _Tk_Button(ttk.Button):
+    '''A C{_Tk_Button} with a label, inlieu of text.
+    '''
+    def __init__(self, frame, **kwds):
+        cfg = self._cfg(**kwds)
+        ttk.Button.__init__(self, frame, **cfg)
+
+    def _cfg(self, label=None, **kwds):
+        if label is None:
+            cfg = kwds
+        else:
+            cfg = dict(text=label)
+            cfg.update(kwds)
+        return cfg
+
+    def config(self, **kwds):
+        cfg = self._cfg(**kwds)
+        ttk.Button.config(self, **cfg)
+
+    def disabled(self, *disable):
+        '''Dis-/enable this button.
+        '''
+        # <https://TkDocs.com/tutorial/widgets.html>
+        p = self.instate(_DISABLED)
+        if disable:
+            self.state(_DISABLED if disable[0] else _ENABLED)
+        return bool(p)
+
+
+class _Tk_Item(object):
+    '''A re-configurable C{_Tk_Menu} item.
+    '''
+    def __init__(self, menu, label='', key='', under='', **kwds):
+        '''New menu item.
+        '''
+        self.menu = menu
+        self.item = menu.index(label)
+        self.key  = key  # <...>
+
+        self._cfg_d = dict(label=label, **kwds)
+        self._dis_d = False
+        self._under = under  # lower case
+
+    def config(self, **kwds):
+        '''Reconfigure this menu item.
+        '''
+        cfg = self._cfg_d.copy()
+        cfg.update(kwds)
+        if self._under:  # update underlining
+            _, cfg = _underline2(self._under, **cfg)
+        self.menu.entryconfig(self.item, **cfg)
+
+    def disabled(self, *disable):
+        '''Dis-/enable this menu item.
+        '''
+        # <https://TkDocs.com/tutorial/menus.html>
+        p = self._dis_d
+        if disable:
+            self._dis_d = d = bool(disable[0])
+            self.config(state=Tk.DISABLED if d else Tk.NORMAL)
+        return p
 
 
 class _Tk_Menu(Tk.Menu):
-    '''Tk.Menu extended with .add_shortcut method.  Note, this is a
-       kludge just to get Command-key shortcuts to work on macOS.
-       Modifiers like Ctrl-, Shift- and Option- are not handled!
+    '''C{Tk.Menu} extended with an C{.add_shortcut} method.
+
+       Note, make C{Command-key} shortcuts on macOS work like
+       C{Control-key} shotcuts on X-/Windows using a *single*
+       character shortcut.
+
+       Other modifiers like Shift- and Option- passed thru,
+       unmodified.
     '''
-    _shortcuts_entries = {}
-    _shortcuts_widget  = None
+    _shortcuts_entries = None  # {}, see .bind_shortcuts_to
+    _shortcuts_widgets = ()
 
-    def add_shortcut(self, label='', key='', command=None, **kwds):
-        '''Like Tk.menu.add_command extended with shortcut key.
+    def __init__(self, master=None, **kwds):
+        # remove dashed line from X-/Windows tearoff menus
+        # like idlelib.editor.EditorWindow.createmenubar
+        # or use root.option_add('*tearOff', False)  Off?
+        # as per <https://TkDocs.com/tutorial/menus.html>
+        Tk.Menu.__init__(self, master, tearoff=False, **kwds)
+
+    def add_item(self, label='', command=None, key='', **kwds):
+        '''C{Tk.menu.add_command} extended with shortcut key
+           accelerator, underline and binding and returning
+           a C{_Tk_Item} instance instead of an C{item} index.
+
            If needed use modifiers like Shift- and Alt_ or Option-
-           as before the shortcut key character.  Do not include
-           the Command- or Control- modifier nor the <...> brackets
-           since those are handled here, depending on platform and
-           as needed for the binding.
+           before the *single* shortcut key character.  Do NOT
+           include the Command- or Control- modifier, instead use
+           the platform-specific Cmd_, like Cmd_ + key.  Also,
+           do NOT enclose the key in <...> brackets since those
+           are handled here as needed for the shortcut binding.
         '''
-        # <https://TkDocs.com/tutorial/menus.html>
-        if not key:
-            self.add_command(label=label, command=command, **kwds)
+        assert callable(command), 'command=%r' % (command,)
+        return self._Item(Tk.Menu.add_command, key, label,
+                                  command=command, **kwds)
 
-        elif _isMacOS:
-            # keys show as upper-case, always
-            self.add_command(label=label, accelerator=C_Key + key,
-                                          command=command, **kwds)
-            self.bind_shortcut(key, command, label)
-
-        else:  # XXX not tested, not tested, not tested
-            self.add_command(label=label, underline=label.lower().index(key),
-                                          command=command, **kwds)
-            self.bind_shortcut(key, command, label)
-
-    def bind_shortcut(self, key, command, label=None):
-        '''Bind shortcut key, default modifier Command/Control.
+    def add_menu(self, label='', menu=None, key='', **kwds):  # untested
+        '''C{Tk.menu.add_cascade} extended with shortcut key
+           accelerator, underline and binding and returning
+           a C{_Tk_Item} instance instead of an C{item} index.
         '''
-        # The accelerator modifiers on macOS are Command-,
+        assert isinstance(menu, _Tk_Menu), 'menu=%r' % (menu,)
+        return self._Item(Tk.Menu.add_cascade, key, label,
+                                  menu=menu, **kwds)
+
+    def bind_shortcut(self, key='', command=None, label='', **unused):
+        '''Bind shortcut key "<modifier-...-name>".
+        '''
+        # C{Accelerator} modifiers on macOS are Command-,
         # Ctrl-, Option- and Shift-, but for .bind[_all] use
-        # <Command-..>, <Ctrl-..>, <Option_..> and <Shift-..>,
+        # <Command-..>, <Ctrl-..>, <Option_..> and <Shift-..>
+        # with a shortcut key name or character (replaced
+        # with its _KEY_SYMBOL if non-alphanumeric)
         # <https://www.Tcl.Tk/man/tcl8.6/TkCmd/bind.htm#M6>
-        if self._shortcuts_widget:
-            if C_Key.lower() not in key.lower():
-                key = '<%s%s>' % (C_Key, key.lstrip('<').rstrip('>'))
-            self._shortcuts_widget.bind(key, command)
-            # remember the shortcut key for this menu item
-            if label is not None:
+        # <https://www.Tcl.Tk/man/tcl8.6/TkCmd/keysyms.html>
+        if key and callable(command) and self._shortcuts_widgets:
+            for w in self._shortcuts_widgets:
+                w.bind(key, command)
+            if label:  # remember the key in this menu
                 item = self.index(label)
                 self._shortcuts_entries[item] = key
-        # The Tk modifier for macOS' Command key is called
-        # Meta, but there is only Meta_L[eft], no Meta_R[ight]
-        # and both keyboard command keys generate Meta_L events.
-        # Similarly for macOS' Option key, the modifier name is
-        # Alt and there's only Alt_L[eft], no Alt_R[ight] and
-        # both keyboard option keys generate Alt_L events.  See:
+        # The Tk modifier for macOS' Command key is called Meta
+        # with Meta_L and Meta_R for the left and right keyboard
+        # keys.  Similarly for macOS' Option key, the modifier
+        # name Alt with Alt_L and Alt_R.  Previously, there were
+        # only the Meta_L and Alt_L keys/modifiers.  See also
         # <https://StackOverflow.com/questions/6378556/multiple-
         # key-event-bindings-in-tkinter-control-e-command-apple-e-etc>
 
-    def bind_shortcuts_to(self, widget):
-        '''Set the widget for the shortcut keys, usually root.
+    def bind_shortcuts_to(self, *widgets):
+        '''Set widget(s) to bind shortcut keys to, usually the
+           root and/or Toplevel widgets.
         '''
-        self._shortcuts_widget = widget
+        self._shortcuts_entries = {}
+        self._shortcuts_widgets = widgets
 
-    def entryconfig(self, item, **kwds):  # PYCHOK signature
-        '''Update shortcut key binding if menu entry changed.
+    def entryconfig(self, idx, command=None, **kwds):  # PYCHOK signature
+        '''Update a menu item and the shortcut key binding
+           if the menu item command is being changed.
+
+           Note, C{idx} is the item's index in the menu,
+           see C{_Tk_Item} above.
         '''
-        Tk.Menu.entryconfig(self, item, **kwds)
-        # adjust the shortcut key binding also
-        if self._shortcuts_widget:
-            key = self._shortcuts_entries.get(item, None)
-            if key is not None and 'command' in kwds:
-                self._shortcuts_widget.bind(key, kwds['command'])
+        if command is None:  # XXX postcommand for sub-menu
+            Tk.Menu.entryconfig(self, idx, **kwds)
+        else:  # adjust the shortcut key binding also
+            Tk.Menu.entryconfig(self, idx, command=command, **kwds)
+            key = self._shortcuts_entries.get(idx, None)
+            if key is not None:
+                for w in self._shortcuts_widgets:
+                    w.bind(key, command)
+
+    def _Item(self, _add, key, label, **kwds):
+        # Add and bind a menu item or sub~menu with an
+        # optional accelerator key (not <..> enclosed)
+        # or underline letter (preceded by underscore),
+        # see <https://TkDocs.com/tutorial/menus.html>.
+        cfg = dict(label=label)
+        if key:  # Use '+' sign, like key = "Ctrl+Shift+X"
+            if key.startswith('<') and key.endswith('>'):
+                c = ''  # pass as-is, e.g. <<virtual event>>
+            else:
+                c = '+'  # split into modifiers and char
+                if key.endswith(c):
+                    m = key.rstrip(c).split(c)
+                else:
+                    m = key.split(c)
+                    c = m.pop()
+                # adjust accelerator key for specials like KP_1,
+                # PageDown and PageUp (on macOS, see function
+                # ParseAccelerator in <https://GitHub.com/tcltk/tk/
+                # blob/main/macosx/tkMacOSXMenu.c> and definition
+                # of specialAccelerators in <https://GitHub.com/
+                # tcltk/tk/blob/main/macosx/tkMacOSXMenu.c>)
+                a = _MAC_ACCEL.get(c, c) if _isMacOS else c
+                if a.upper().startswith('KP_'):
+                    a = a[3:]
+                # accelerator keys are shown only in menus
+                cfg.update(accelerator='+'.join(m + [a]))
+                # replace key with Tk keysymb, allow F1 thru F35
+                # (F19 on macOS) and because shortcut keys are
+                # case-sensitive, use lower-case unless specified
+                # as an upper-case letter with Shift+ modifier
+                s = _KEY_SYMBOL.get(c, c)
+                if len(s) == 1 and s.isupper() \
+                               and 'Shift' not in m:
+                    s = s.lower()
+                # replace Ctrl- modifier with Control-
+                if 'Ctrl' in m:
+                    m[m.index('Ctrl')] = 'Control'
+                # enclosed for .bind_shortcut/.bind
+                key = '<' + '-'.join(m + [s]) + '>'
+                if _isMacOS or len(c) != 1 or not c.isalnum():
+                    c = ''  # no underlining
+                else:  # only Windows?
+                    c, cfg = _underline2(c, **cfg)
+
+        else:  # like idlelib, underline char after ...
+            c, u = '', label.find('_')  # ... underscore
+            if u >= 0:  # ... and remove underscore
+                label = label[:u] + label[u+1:]
+                cfg.update(label=label)
+                if u < len(label) and not _isMacOS:
+#                   c = label[u]
+                    cfg.update(underline=u)
+
+        if kwds:  # may still override accelerator ...
+            cfg.update(kwds)  # ... and underline
+        _add(self, **cfg)  # first _add then ...
+        self.bind_shortcut(key, **cfg)  # ... bind
+        return _Tk_Item(self, key=key, under=c, **cfg)
+
+
+class _Tk_Slider(Tk.Scale):
+    '''Scale with some add'l attributres
+    '''
+    _var = None
+
+    def __init__(self, frame, to=1, **kwds):
+        if isinstance(to, int):
+            f, v = 0, Tk.IntVar()
+        else:
+            f, v = 0.0, Tk.DoubleVar()
+        cfg = dict(from_=f, to=to,
+                   orient=Tk.HORIZONTAL,
+                   showvalue=0,
+                   variable=v)
+        cfg.update(kwds)
+        Tk.Scale.__init__(self, frame, **cfg)
+        self._var = v
+
+    def set(self, value):
+        # doesn't move the slider
+        self._var.set(value)
+        Tk.Scale.set(self, value)
 
 
 class Player(Tk.Frame):
-    '''The main window has to deal with events.
+    '''The main window handling with events, etc.
     '''
-    _debugs    = 0
-    _geometry  = ''
-    _MIN_WIDTH = 600
-    _stopped   = None
+    _anchored  =  True  # under the video panel
+    _BUTTON_H  = _BANNER_H
+    _buttons_g = ''  # or geometry
+    _debugged  =  0
+    _isFull    = ''  # or geometry
+    _length    =  0  # length time ticks
+    _lengthstr = ''  # length h:m:s
+    _muted     =  False
+    _opacity   =  90 if _isMacOS else 100  # percent
+    _opaque    =  False
+    _rate      =  0.0
+    _scale     =  0.0
+    _scale_1X  =  0.0
+    _sliding   =  False
+    _snapshots =  0
+    _stopped   =  None
+    _title     = 'tkVLCplayer'
+    _video_g   = ''  # or geometry
+    _volume    =  50  # percent
+    _zoomX     =  1
 
-    def __init__(self, parent, title=None, video='', debug=False):  # PYCHOK called!
+    def __init__(self, parent, title='', video='', debug=False):  # PYCHOK called!
         Tk.Frame.__init__(self, parent)
 
         self.debug  = bool(debug)
         self.parent = parent  # == root
-        self.parent.title(title or 'tkVLCplayer')
-        self.video = os.path.expanduser(video)
+        self.video  = os.path.expanduser(video)
+        if title:
+            self._title = str(title)
+        parent.title(title)
+#       parent.iconname(title)
 
-        # Menu Bar
-        menubar = Tk.Menu(self.parent)
-        self.parent.config(menu=menubar)
-        # File Menu
-        fileMenu = _Tk_Menu(menubar)
-        fileMenu.bind_shortcuts_to(parent)  # XXX must be root?
+        # set up tickers to avoid None error
+        def _pass():
+            pass
+        self._tick_1 = self.after(1, _pass)
+        self._tick_2 = self.after(2, _pass)
+        self._tick_3 = self.after(3, _pass)
+        self._tick_4 = self.after(4, _pass)  # .after_idle
 
-        fileMenu.add_shortcut('Open...', 'o', self.OnOpen)
-        fileMenu.add_separator()
-        fileMenu.add_shortcut('Play', 'p', self.OnPlay)  # Play/Pause
-        fileMenu.add_command(label='Stop', command=self.OnStop)
-        fileMenu.add_separator()
-        fileMenu.add_shortcut('Mute', 'm', self.OnMute)
-        fileMenu.add_separator()
-        fileMenu.add_shortcut('Close', 'w' if _isMacOS else 's', self.OnClose)
-        fileMenu.add_separator()
-        fileMenu.add_shortcut('Buttons Up', 'a', self.OnAnchor)
-        self.anchorIndex = fileMenu.index('Buttons Up')
-        fileMenu.add_separator()
-        fileMenu.add_shortcut('Full Screen', 'f', self.OnScreen)
-        self.fullIndex = fileMenu.index('Full Screen')
-        menubar.add_cascade(label='File', menu=fileMenu)
-        self.fileMenu = fileMenu
-        self.playIndex = fileMenu.index('Play')
-        self.muteIndex = fileMenu.index('Mute')
+        # panels to play videos and hold buttons, sliders,
+        # created *before* the File menu to be able to bind
+        # the shortcuts keys to both windows/panels.
+        self.videoPanel = v = self._VideoPanel()
+        self._handleEvents(v)  # or parent
+        self.buttonsPanel = b = self._ButtonsPanel()
+        self._handleEvents(b)
 
-        # first, panel shows video
-        self.videoPanel = ttk.Frame(self.parent)
-        self.canvas = Tk.Canvas(self.videoPanel)
-        self.canvas.pack(fill=Tk.BOTH, expand=1)
-        self.videoPanel.pack(fill=Tk.BOTH, expand=1)
+        mb = _Tk_Menu(self.parent)  # menu bar
+        parent.config(menu=mb)
+#       self.menuBar = mb
 
-        # panel to hold buttons
-        self.buttonsPanel = Tk.Toplevel(self.parent)
-        self.buttonsPanel.title('')
-        self.buttonsPanel_anchored = False
-        self.buttonsPanel_clicked  = False
-        self.buttonsPanel_dragged  = False
+        # macOS shortcuts <https://Support.Apple.com/en-us/HT201236>
+        m = _Tk_Menu(mb)  # Video menu, shortcuts to both panels
+        m.bind_shortcuts_to(v, b)
+        m.add_item('Open...', self.OnOpen, key=Cmd_ + 'O')
+        m.add_separator()
+        self.playItem = m.add_item('Play', self.OnPlay, key=Cmd_ + 'P')  # Play/Pause
+        m.add_item('Stop', self.OnStop, key=Cmd_ + '\b')  # BackSpace
+        m.add_separator()
+        self.muteItem = m.add_item('Mute', self.OnMute, key=Cmd_ + 'M')
+        if _isWindows:  # XXX black areas in zoomed videoPanel on macOS
+            m.add_separator()
+            m.add_item('Zoom In',  self.OnZoomIn,  key=Cmd_ + 'Shift++')
+            m.add_item('Zoom Out', self.OnZoomOut, key=Cmd_ + '-')
+            m.add_separator()
+            m.add_item('Normal 1X', self.OnNormal, key=Cmd_ + '=')
+            m.add_separator()
+            m.add_item('Faster', self.OnFaster, key=Cmd_ + 'Shift+>')
+            m.add_item('Slower', self.OnSlower, key=Cmd_ + 'Shift+<')
+        m.add_separator()
+        m.add_item('Snapshot', self.OnSnapshot, key=Cmd_ + 'T')
+        m.add_separator()
+        self.fullItem = m.add_item(_FULL_SCREEN, self.OnFull, key=Cmd_ + 'F')
+        m.add_separator()
+        m.add_item('Close', self.OnClose, key=Cmd_ + 'W')
+        mb.add_cascade(label='Video', menu=m)
+#       self.videoMenu = m
 
-        buttons = ttk.Frame(self.buttonsPanel)
-        self.playButton   = ttk.Button(buttons, text='Play', command=self.OnPlay, underline=0)
-        stop              = ttk.Button(buttons, text='Stop', command=self.OnStop)
-        self.muteButton   = ttk.Button(buttons, text='Mute', command=self.OnMute, underline=0)
-        self.playButton.pack(side=Tk.LEFT, padx=8)
-        stop.pack(side=Tk.LEFT)
-        self.muteButton.pack(side=Tk.LEFT, padx=8)
-        self.volMuted = False
-        self.volVar = Tk.IntVar()
-        self.volSlider = Tk.Scale(buttons, variable=self.volVar, command=self.OnVolume,
-                                  from_=0, to=100, orient=Tk.HORIZONTAL, length=170,
-                                  showvalue=0, label='Volume')
-        self.volSlider.pack(side=Tk.LEFT)
+        m = _Tk_Menu(mb)  # Video menu, shortcuts to both panels
+        m.bind_shortcuts_to(v, b)
+        self.anchorItem = m.add_item(_UN_ANCHORED, self.OnAnchor, key=Cmd_ + 'A')
+        m.add_separator()
+        self.opaqueItem = m.add_item(_OPACITY % (self._opacity,), self.OnOpacity, key=Cmd_ + 'Y')
+        m.add_item('Normal 100%', self.OnOpacity100)
+        mb.add_cascade(label=_BUTTONS, menu=m)
+#       self.buttonsMenu = m
 
-        self.anchorButton = ttk.Button(buttons, text='Up', command=self.OnAnchor,
-                                       width=2)  # in characters
-        self.anchorButton.pack(side=Tk.RIGHT, padx=8)
-        buttons.pack(side=Tk.BOTTOM, fill=Tk.X)
-
-        # <https://www.PythonTutorial.net/tkinter/tkinter-window>
-        # <https://TkDocs.com/tutorial/windows.html>
-        # self.buttonsPanel.attributes('-topmost', 1)
-
-        self.buttonsPanel.update()
-        self.videoPanel.update()
-
-        # panel to hold player time slider
-        timers = ttk.Frame(self.buttonsPanel)
-        self.timeVar = Tk.DoubleVar()
-        self.timeSliderLast = 0
-        self.timeSlider = Tk.Scale(timers, variable=self.timeVar, command=self.OnTime,
-                                   from_=0, to=1000, orient=Tk.HORIZONTAL, length=500,
-                                   showvalue=0)  # label='Time',
-        self.timeSlider.pack(side=Tk.BOTTOM, fill=Tk.X, expand=1)
-        self.timeSliderUpdate = time.time()
-        timers.pack(side=Tk.BOTTOM, fill=Tk.X)
+        if _isMacOS and self.debug:  # Special macOS "windows" menu
+            # <https://TkDocs.com/tutorial/menus.html> "Providing a Window Menu"
+            # XXX Which (virtual) events are generated other than Configure?
+            m = _Tk_Menu(mb, name='window')  # must be name='window'
+            mb.add_cascade(menu=m, label='Windows')
 
         # VLC player
-        args = []
-        if _isLinux:
-            args.append('--no-xlib')
+        args = ['--no-xlib'] if _isLinux else []
         self.Instance = vlc.Instance(args)
         self.player = self.Instance.media_player_new()
 
-        self.parent.bind('<Configure>', self.OnConfigure)  # catch window resize, etc.
-        self.parent.update()
-
-        # After parent.update() otherwise panel is ignored.
-        self.buttonsPanel.overrideredirect(True)
-        self.buttonsPanel_anchored = True  # down, under the video panel
-
-        if _dragging:  # Detect dragging of the buttons panel.
-            self.buttonsPanel.bind('<Button-1>',        self._Button1Down)
-            self.buttonsPanel.bind('<B1-Motion>',       self._Button1Motion)
-            self.buttonsPanel.bind('<ButtonRelease-1>', self._Button1Up)
-
-        # Keep the video panel at least as wide as thebuttons panel.
-        self.parent.minsize(width=self._MIN_WIDTH, height=0)
-
-        self._AnchorPanels(force=True)
-
+        b.update_idletasks()
+        v.update_idletasks()
+        if self.video:  # play video for a second, adjusting the panel
+            self._play(self.video)
+            self.after(1000, self.OnPause)
+#       elif _isMacOS:  # <https://StackOverflow.com/questions/18394597/
+#           # is-there-a-way-to-create-transparent-windows-with-tkinter>
+#           self._stopped = True
+#           self._set_opacity()
         self.OnTick()  # set up the timer
 
-        if self.video:  # play for a second
-            self.OnPlay()
-            self.parent.after(1000, self.OnPause)
+        # Keep the video panel at least as wide as the buttons panel
+        # and move it down enough to put the buttons panel above it.
+        self._BUTTON_H = d = b.winfo_height()
+        b.minsize(width=_MIN_W, height=d)
+        v.minsize(width=_MIN_W, height=0)
+        _, w, h, _, y = _geometry5(v)
+        y = int(y) + d + _BANNER_H
+        _geometry(v, w, h, _TAB_X, y)
+        self._anchorPanels()
+        self._set_volume()
 
-    def _Button1Down(self, *unused):  # only if -dragging
-        self._debug(self._Button1Down)
-        # Left-mouse-button pressed inside the buttons
-        # panel, but not in and over a slider-/button.
-        self.buttonsPanel_clicked = True
-        self.buttonsPanel_dragged = False
+    def _anchorPanels(self, video=False):
+        # Put the buttons panel under the video
+        # or the video panel above the buttons
+        if self._anchored and not self._isFull:
+            self._debug(self._anchorPanels)
+            v = self.videoPanel
+            if _isMacOS and _full_screen(v):
+                # macOS green button full-screen?
+                _full_screen(v, False)
+                self.OnFull()
+            else:
+                b = self.buttonsPanel
+                v.update_idletasks()
+                b.update_idletasks()
+                h = v.winfo_height()
+                d = h + _BANNER_H  # vertical delta
+                if video:  # move/adjust video panel
+                    w = b.winfo_width()  # same as ...
+                    x = b.winfo_x()      # ... buttons
+                    y = b.winfo_y() - d  # ... and above
+                    g = v
+                else:  # move/adjust buttons panel
+                    h = b.winfo_height()  # unchanged
+                    if h > self._BUTTON_H and _full_screen(b):
+                        # macOS green button full-screen?
+                        _full_screen(b, False)
+                        h = self._BUTTON_H
+                    w = v.winfo_width()  # unchanged
+                    x = v.winfo_x()  # same as the video
+                    y = v.winfo_y() + d  # below the video
+                    g = b
+                _g = _geometry(g, max(w, _MIN_W), h, x, y)
+                if g is v:
+                    self._set_aspect(True)
+                else:
+                    self._buttons_g = _g
 
-    def _Button1Motion(self, *unused):  # only if -dragging
-        self._debug(self._Button1Motion)
-        # Mouse dragged, moved with left-mouse-button down?
-        self.buttonsPanel_dragged = self.buttonsPanel_clicked
+    def _ButtonsPanel(self):
+        # create panel with buttons and sliders
+        b = Tk.Toplevel(self.parent, name='buttons')
+        t = '%s - %s' % (self._title, _BUTTONS)
+        b.title(t)  # '' removes the banner
+        b.resizable(True, False)
 
-    def _Button1Up(self, *unused):  # only if -dragging
-        self._debug(self._Button1Up)
-        # Left-mouse-button release
-        if self.buttonsPanel_clicked:
-            if self.buttonsPanel_dragged:
-                # If the mouse was dragged in the buttons
-                # panel on the background, un-/anchor it.
-                self.OnAnchor()
-#               if _dragged:
-#                   self.buttonsPanel.unbind('<Button-1>')
-#                   self.buttonsPanel.unbind('<B1-Motion>')
-#                   self.buttonsPanel.unbind('<ButtonRelease-1>')
-        self.buttonsPanel_clicked = False
-        self.buttonsPanel_dragged = False
+        f = ttk.Frame(b)
+        # button are too small on Windows if width is given
+        p = _Tk_Button(f, label='Play', command=self.OnPlay)
+        #                 width=len('Pause'), underline=0
+        s = _Tk_Button(f, label='Stop', command=self.OnStop)
+        m = _Tk_Button(f, label='Mute', command=self.OnMute)
+        #                 width=len('Unmute'), underline=0
+        q = _Tk_Slider(f, command=self.OnPercent, to=100,
+                          label=_VOLUME)  # length=170
+        p.pack(side=Tk.LEFT, padx=8)
+        s.pack(side=Tk.LEFT)
+        m.pack(side=Tk.LEFT, padx=8)
+        q.pack(fill=Tk.X,    padx=4, expand=1)
+        f.pack(side=Tk.BOTTOM, fill=Tk.X)
 
-    def _debug(self, where, **kwds):
+        f = ttk.Frame(b)  # new frame?
+        t = _Tk_Slider(f, command=self.OnTime, to=1000,  # millisecs
+                          length=_MIN_W)  # label='Time'
+        t.pack(side=Tk.BOTTOM, fill=Tk.X, expand=1)
+        f.pack(side=Tk.BOTTOM, fill=Tk.X)
+
+        # <https://www.PythonTutorial.net/tkinter/tkinter-window>
+        # <https://TkDocs.com/tutorial/windows.html>
+        # b.attributes('-topmost', 1)
+
+        # self.videoPanel.update()  # needed to ...
+# #     b.overrideredirect(True)  # ignore the panel
+        b.update_idletasks()
+
+        self.muteButton    = m
+        self.playButton    = p
+        self.timeSlider    = t
+        self.percentSlider = q
+        return b
+
+    def _debug(self, where, *args, **kwds):
         # Print where an event is are handled.
         if self.debug:
-            self._debugs += 1
-            d = dict(anchored=self.buttonsPanel_anchored,
-                      clicked=self.buttonsPanel_clicked,
-                      dragged=self.buttonsPanel_dragged,
-                      playing=self.player.is_playing(),
-                      stopped=self._stopped)
+            self._debugged += 1
+            d = dict(anchored=self._anchored,
+                       isFull=bool(self._isFull),
+                      opacity=self._opacity,
+                       opaque=self._opaque,
+                      stopped=self._stopped,
+                       volume=self._volume)
+            p = self.player
+            if p and p.get_media():
+                d.update(playing=p.is_playing(),
+                            rate=p.get_rate(),
+                           scale=p.video_get_scale(),
+                        scale_1X=self._scale_1X)
+            try:  # final OnClose may throw TclError
+                d.update(Buttons=_geometry1(self.buttonsPanel))
+                d.update(  Video=_geometry1(self.videoPanel))
+                if args:  # an event
+                    e = args[0]
+                    d.update(event=e)
+                    w = str(e.widget)
+#                   d.update(widget=type(event.widget))  # may fail
+                    d.update(Widget={'.':        'Video',
+                                     '.buttons': _BUTTONS}.get(w, w))
+            except (AttributeError, TclError):
+                pass
             d.update(kwds)
             d = ', '.join('%s=%s' % t for t in sorted(d.items()))
-            print('%4s: %s %s' % (self._debugs, where.__name__, d))
+            print('%4s: %s %s' % (self._debugged, where.__name__, d))
 
-    def _AnchorPanels(self, force=False):
-        # Un-/anchor the buttons under the video panel, at the same width.
-        self._debug(self._AnchorPanels)
-        if (force or self.buttonsPanel_anchored):
-            video = self.parent
-            h = video.winfo_height()
-            w = video.winfo_width()
-            x = video.winfo_x()  # i.e. same as the video
-            y = video.winfo_y() + h + 32  # i.e. below the video
-            h = self.buttonsPanel.winfo_height()  # unchanged
-            w = max(w, self._MIN_WIDTH)  # i.e. same a video width
-            self.buttonsPanel.geometry('%sx%s+%s+%s' % (w, h, x, y))
+    def _handleEvents(self, panel):
+        # set up handlers for several events
+        try:
+            p  = panel
+            p_ = p.protocol
+        except AttributeError:
+            p  = p.master  # == p.parent
+            p_ = p.protocol
+        if _isWindows:  # OK for macOS
+            p_('WM_DELETE_WINDOW', self.OnClose)
+#       Event Types <https://www.Tcl.Tk/man/tcl8.6/TkCmd/bind.html#M7>
+        p.bind('<Configure>',  self.OnConfigure)  # window resize, position, etc.
+        # needed on macOS to catch window close events
+        p.bind('<Destroy>',    self.OnClose)      # window half-dead
+#       p.bind('<Activate>',   self.OnActive)     # window activated
+#       p.bind('<Deactivate>', self.OffActive)    # window deactivated
+        p.bind('<FocusIn>',    self.OnFocus)      # getting keyboard focus
+#       p.bind('<FocusOut>',   self.OffFocus)     # losing keyboard focus
 
     def OnAnchor(self, *unused):
-        '''Toggle buttons panel anchoring.
+        '''Toggle anchoring of the panels.
         '''
-        c = self.OnAnchor
-        self._debug(c)
-        self.buttonsPanel_anchored = not self.buttonsPanel_anchored
-        if self.buttonsPanel_anchored:
-            a = 'Up'
-            self._AnchorPanels(force=True)
-        else:  # move the panel to the top left corner
-            a = 'Down'
-            h = self.buttonsPanel.winfo_height()  # unchanged
-            self.buttonsPanel.geometry('%sx%s+8+32' % (self._MIN_WIDTH, h))
-        self.anchorButton.config(text=a, width=len(a))
-        a = 'Buttons ' + a
-        self.fileMenu.entryconfig(self.anchorIndex, label=a, command=c)
-        # self.fileMenu.bind_shortcut('a', c)  # XXX handled
+        self._debug(self.OnAnchor)
+        self._anchored = not self._anchored
+        if self._anchored:
+            self._anchorPanels()
+            a = _UN_ANCHORED
+        else:  # move the buttons panel to the top-left
+            b = self.buttonsPanel
+            h = b.winfo_height()  # unchanged
+            _geometry(b, _MIN_W, h, _TAB_X, _BANNER_H)
+            a = _ANCHORED
+        self.anchorItem.config(label=a)
 
-    def OnClose(self, *unused):
-        '''Closes the window and quit.
+    def OnClose(self, *event):
+        '''Closes the window(s) and quit.
         '''
-        self._debug(self.OnClose)
+        self._debug(self.OnClose, *event)
         # print('_quit: bye')
-        self.parent.quit()  # stops mainloop
-        self.parent.destroy()  # this is necessary on Windows to avoid
-        # ... Fatal Python Error: PyEval_RestoreThread: NULL tstate
+        self.after_cancel(self._tick_1)
+        self.after_cancel(self._tick_2)
+        self.after_cancel(self._tick_3)
+        self.after_cancel(self._tick_4)
+        v = self.videoPanel
+        v.update_idletasks()
+        self.quit()  # stops .mainloop
 
-    def OnConfigure(self, *unused):
+    def OnConfigure(self, event):
         '''Some widget configuration changed.
         '''
-        self._debug(self.OnConfigure)
-        # <https://www.Tcl.Tk/man/tcl8.6/TkCmd/bind.htm#M12>
-        self._geometry = ''  # force .OnResize in .OnTick, recursive?
-        self._AnchorPanels()
+        w, T = event.widget, event.type  # int
+        if T == _T_CONFIGURE and w.winfo_toplevel() is w:
+            # i.e. w is videoFrame/Panel or buttonsPanel
+            if w is self.videoPanel:
+                a = self._set_aspect  # force=True
+                g = self._video_g
+            elif w is self.buttonsPanel and self._anchored:
+                a = self._anchorPanels  # video=True
+                g = self._buttons_g
+            else:
+                a = g = None
+            # prevent endless, recursive onConfigure events due to changing
+            # the buttons- and videoPanel geometry, especially on Windows
+            if a and g != _geometrys(event.width, event.height, event.x, event.y):
+                self.after_cancel(self._tick_1)
+                self._debug(self.OnConfigure, event)
+                self._tick_1 = self.after(250, a, True)
+
+    def OnFaster(self, *unused):
+        '''Speed the video up by 25%.
+        '''
+        self._set_rate(1.25)
+        self._debug(self.OnFaster)
+
+    def OnFocus(self, *unused):
+        '''Got the keyboard focus.
+        '''
+        self._debug(self.OnFocus)
+        self._set_aspect()
+#       self._wiggle()
+
+    def OnFull(self, *unused):
+        '''Toggle full/off screen.
+        '''
+        self._debug(self.OnFull)
+        # <https://www.Tcl.Tk/man/tcl8.6/TkCmd/wm.htm#M10>
+        # self.after_cancel(self._tick_2)
+        v = self.videoPanel
+        if not _full_screen(v):
+            self._isFull = _geometry1(v)
+            _full_screen(v, True)  # or .wm_attributes
+            v.bind('<Escape>', self.OnFull)
+            f = _FULL_OFF
+        else:
+            _full_screen(v, False)
+            v.unbind('<Escape>')
+            _geometry(v, self._isFull)
+            self._isFull = ''
+            self._anchorPanels()
+            f = _FULL_SCREEN
+        self.fullItem.config(label=f)
 
     def OnMute(self, *unused):
         '''Mute/Unmute audio.
         '''
+        if self._stopped or self._opaque:
+            return  # button.disabled
         self._debug(self.OnMute)
-        self.buttonsPanel_clicked = False
         # audio un/mute may be unreliable, see vlc.py docs.
-        self.volMuted = m = not self.volMuted  # self.player.audio_get_mute()
+        self._muted = m = not self._muted  # self.player.audio_get_mute()
         self.player.audio_set_mute(m)
         u = 'Unmute' if m else 'Mute'
-        self.fileMenu.entryconfig(self.muteIndex, label=u)
-        self.muteButton.config(text=u)
-        # update the volume slider text
-        self.OnVolume()
+        # i = u.index('m' if m else 'M')  # 2 if m else 0
+        self.muteItem.config(label=u)
+        self.muteButton.config(label=u)  # width=len(u), underline=i
+        self.OnPercent()  # re-label the slider
+
+    def OnNormal(self, *unused):
+        '''Normal speed and 1X zoom.
+        '''
+        self._set_rate(0.0)
+        self._set_zoom(0.0)
+#       self._wiggle()
+        _frontmost(self.buttonsPanel, True)
+        _frontmost(self.videoPanel, True)
+        self._set_aspect(True)
+        self._debug(self.OnNormal)
+
+    def OnOpacity(self, *unused):
+        '''Use the percent slider to adjust the opacity.
+        '''
+        self.muteButton.disabled(True)  # greyed out?
+        self.muteItem.disabled(True)  # greyed out?
+        self._opaque = True
+        self._set_opacity()
+        self._debug(self.OnOpacity)
+
+    def OnOpacity100(self, *unused):
+        '''Set the opacity to 100%.
+        '''
+        _frontmost(self.videoPanel, True)
+        _frontmost(self.buttonsPanel, True)
+        self._set_opacity(100)
+        self._debug(self.OnOpacity100)
 
     def OnOpen(self, *unused):
-        '''Pop up a new dialow window to choose a file, then play the selected file.
+        '''Show the file dialog to choose a video, then play it.
         '''
-        # if a file is already running, then stop it.
-        self.OnStop()
-        # Create a file dialog opened in the current home directory, where
-        # you can display all kind of files, having as title 'Choose a video'.
-        video = askopenfilename(initialdir = Path(os.path.expanduser('~')),
-                                title = 'Choose a video',
-                                filetypes = (('all files', '*.*'),
-                                             ('mp4 files', '*.mp4'),
-                                             ('mov files', '*.mov')))
-        self._Play(video)
-
-    def _Pause_Play(self, playing):
-        # re-label menu item and button, adjust callbacks
-        p = 'Pause' if playing else 'Play'
-        c = self.OnPlay if playing is None else self.OnPause  # PYCHOK attr
-        self.fileMenu.entryconfig(self.playIndex, label=p, command=c)
-        # self.fileMenu.bind_shortcut('p', c)  # XXX handled
-        self.playButton.config(text=p, command=c)
-        self._stopped = False
-
-    def _Play(self, video):
-        # helper for OnOpen and OnPlay
-        if os.path.isfile(video):  # Creation
-            m = self.Instance.media_new(str(video))  # Path, unicode
-            self.player.set_media(m)
-            self.parent.title('tkVLCplayer - %s' % (os.path.basename(video),))
-
-            # set the window id where to render VLC's video output
-            h = self.canvas.winfo_id()  # .winfo_visualid()?
-            if _isWindows:
-                self.player.set_hwnd(h)
-            elif _isMacOS:
-                # XXX 1) using the videoPanel.winfo_id() handle
-                # causes the video to play in the entire panel on
-                # macOS, covering the buttons, sliders, etc.
-                # XXX 2) .winfo_id() to return NSView on macOS?
-                v = _GetNSView(h)
-                if v:
-                    self.player.set_nsobject(v)
-                else:
-                    self.player.set_xwindow(h)  # plays audio, no video
-            else:
-                self.player.set_xwindow(h)  # fails on Windows
-            # FIXME: this should be made cross-platform
-            self.OnPlay(None)
+        self._debug(self.OnOpen)
+        self._reset()
+        # XXX ... +[CATransaction synchronize] called within transaction
+        v = askopenfilename(initialdir=os.path.expanduser('~'),
+                            title='Choose a video',
+                            filetypes=(('all files', '*.*'),
+                                       ('mp4 files', '*.mp4'),
+                                       ('mov files', '*.mov')))
+        self._play(os.path.expanduser(v))
+        self._set_aspect(True)
 
     def OnPause(self, *unused):
         '''Toggle between Pause and Play.
         '''
         self._debug(self.OnPause)
-        self.buttonsPanel_clicked = False
-        if self.player.get_media():
-            self._Pause_Play(not self.player.is_playing())
-            self.player.pause()  # toggles
+        p = self.player
+        if p.get_media():
+            self._pause_play(not p.is_playing())
+#           self._wiggle()
+            p.pause()  # toggles
+
+    def OnPercent(self, *unused):
+        '''Percent slider changed, adjust the opacity or volume.
+        '''
+        self._debug(self.OnPercent)
+        s = max(0, min(100, self.percentSlider.get()))
+        if self._opaque or self._stopped:
+            self._set_opacity(s)
+        else:
+            self._set_volume(s)
 
     def OnPlay(self, *unused):
-        '''Play video, if not loaded, open the dialog window.
+        '''Play video, if there's no video to play or
+           playing, show a Tk.FileDialog to select one
         '''
         self._debug(self.OnPlay)
-        self.buttonsPanel_clicked = False
-        # if there's no video to play or playing,
-        # open a Tk.FileDialog to select a file
-        if not self.player.get_media():
+        p = self.player
+        m = p.get_media()
+        if not m:
             if self.video:
-                self._Play(os.path.expanduser(self.video))
+                self._play(self.video)
                 self.video = ''
             else:
                 self.OnOpen()
-        # Try to play, if this fails display an error message
-        elif self.player.play():  # == -1
-            self.showError('Unable to play the video.')
+        elif p.play():  # == -1, play failed
+            self._showError('play ' + repr(m))
         else:
-            self._Pause_Play(True)
-            # set volume slider to audio level
-            vol = self.player.audio_get_volume()
-            if vol > 0:
-                self.volVar.set(vol)
-                self.volSlider.set(vol)
-            self.OnResize()
+            self._pause_play(True)
+            if _isMacOS:
+                self._wiggle()
 
-    def OnResize(self, *unused):
-        '''Adjust the video panel to the video aspect ratio.
+    def OnSlower(self, *unused):
+        '''Slow the video down by 20%.
         '''
-        self._debug(self.OnResize)
-        g = self.parent.geometry()
-        if g != self._geometry and self.player:
-            u, v = self.player.video_get_size()  # often (0, 0)
-            if v > 0 and u > 0:
-                # get window size and position
-                g, x, y = g.split('+')
-                w, h = g.split('x')
-                # alternatively, use .winfo_...
-                # w = self.parent.winfo_width()
-                # h = self.parent.winfo_height()
-                # x = self.parent.winfo_x()
-                # y = self.parent.winfo_y()
-                # use the video aspect ratio ...
-                if u > v:  # ... for landscape
-                    # adjust the window height
-                    h = round(float(w) * v / u)
-                else:  # ... for portrait
-                    # adjust the window width
-                    w = round(float(h) * u / v)
-                self.parent.geometry('%sx%s+%s+%s' % (w, h, x, y))
-                self._geometry = self.parent.geometry()  # actual
-                self._AnchorPanels()
+        self._set_rate(0.80)
+        self._debug(self.OnSlower)
 
-    def OnScreen(self, *unused):
-        '''Toggle full/off screen.
+    def OnSnapshot(self, *unused):
+        '''Take a snapshot and save it (as .PNG only).
         '''
-        c = self.OnScreen
-        self._debug(c)
-        # <https://www.Tcl.Tk/man/tcl8.6/TkCmd/wm.htm#M10>
-        f = not self.parent.attributes('-fullscreen')  # or .wm_attributes
-        if f:
-            self._previouscreen = self.parent.geometry()
-            self.parent.attributes('-fullscreen', f)  # or .wm_attributes
-            self.parent.bind('<Escape>', c)
-            f = 'Off'
-        else:
-            self.parent.attributes('-fullscreen', f)  # or .wm_attributes
-            self.parent.geometry(self._previouscreen)
-            self.parent.unbind('<Escape>')
-            f = 'Full'
-        f += ' Screen'
-        self.fileMenu.entryconfig(self.fullIndex, label=f, command=c)
-        # self.fileMenu.bind_shortcut('f', c)  # XXX handled
+        p = self.player
+        if p and p.get_media():
+            self._snapshots += 1
+            S = 'Snapshot%s' % (self._snapshots,)
+            s = '%s-%s.PNG' % (self._title, S)  # PNG only
+            if p.video_take_snapshot(0, s, 0, 0):
+                self._showError('take ' + S)
 
     def OnStop(self, *unused):
-        '''Stop the player, resets media.
+        '''Stop the player, clear panel, etc.
         '''
         self._debug(self.OnStop)
-        self.buttonsPanel_clicked = False
-        if self.player:
-            self.player.stop()
-            self._Pause_Play(None)
-            # reset the time slider
-            self.timeSlider.set(0)
-            self._stopped = True
-        # XXX on macOS libVLC prints these error messages:
-        # [h264 @ 0x7f84fb061200] get_buffer() failed
-        # [h264 @ 0x7f84fb061200] thread_get_buffer() failed
-        # [h264 @ 0x7f84fb061200] decode_slice_header error
-        # [h264 @ 0x7f84fb061200] no frame!
+        self._reset()
 
     def OnTick(self):
-        '''Timer tick, update the time slider to the video time.
+        '''Udate the time slider with the video time.
         '''
-        if self.player:
-            # since the self.player.get_length may change while
-            # playing, re-set the timeSlider to the correct range
-            t = self.player.get_length() * 1e-3  # to seconds
-            if t > 0:
-                self.timeSlider.config(to=t)
-
-                t = self.player.get_time() * 1e-3  # to seconds
-                # don't change slider while user is messing with it
-                if t > 0 and time.time() > (self.timeSliderUpdate + 2):
-                    self.timeSlider.set(t)
-                    self.timeSliderLast = int(self.timeVar.get())
-        # start the 1 second timer again
-        self.parent.after(1000, self.OnTick)
-        # adjust window to video aspect ratio, done periodically
-        # on purpose since the player.video_get_size() only
-        # returns non-zero sizes after playing for a while
-        self.OnResize()
+        p = self.player
+        if p:
+            s = self.timeSlider
+            if self._length > 0:
+                if not self._sliding:  # see .OnTime
+                    t = max(0, p.get_time() // _TICK_MS)
+                    if t != s.get():
+                        s.set(t)
+                        self._set_buttons(t)
+            else:  # get video length in millisecs
+                t = p.get_length()
+                if t > 0:
+                    self._length = t = max(1, t // _TICK_MS)
+                    self._lengthstr = _hms(t, secs=' secs')
+                    s.config(to=t)  # tickinterval=t / 5)
+        # re-start the 1/4-second timer
+        self._tick_2 = self.after(250, self.OnTick)
 
     def OnTime(self, *unused):
-        if self.player:
-            t = self.timeVar.get()
-            if self.timeSliderLast != int(t):
-                # This is a hack. The timer updates the time slider and
-                # that change causes this rtn (the 'slider has changed')
-                # to be invoked.  I can't tell the difference between the
-                # user moving the slider manually and the timer changing
-                # the slider.  When the user moves the slider, tkinter
-                # only notifies this method about once per second and
-                # when the slider has quit moving.
-                # Also, the tkinter notification value has no fractional
-                # seconds.  The timer update rtn saves off the last update
-                # value (rounded to integer seconds) in timeSliderLast if
-                # the notification time (sval) is the same as the last saved
-                # time timeSliderLast then we know that this notification is
-                # due to the timer changing the slider.  Otherwise the
-                # notification is due to the user changing the slider.  If
-                # the user is changing the slider then I have the timer
-                # routine wait for at least 2 seconds before it starts
-                # updating the slider again (so the timer doesn't start
-                # fighting with the user).
-                self.player.set_time(int(t * 1e3))  # milliseconds
-                self.timeSliderUpdate = time.time()
-
-    def OnVolume(self, *unused):
-        '''Volume slider changed, adjust the audio volume.
+        '''Time slider has been moved by user.
         '''
-        self._debug(self.OnVolume)
-        self.buttonsPanel_clicked = False
-        self.buttonsPanel_dragged = False
-        vol = min(self.volVar.get(), 100)
-        v_M = '%d%s' % (vol, ' (Muted)' if self.volMuted else '')
-        self.volSlider.config(label='Volume ' + v_M)
-        if self.player and not self._stopped:
-            # .audio_set_volume returns 0 if success, -1 otherwise,
-            # e.g. if the player is stopped or doesn't have media
-            if self.player.audio_set_volume(vol):  # and self.player.get_media():
-                self.showError('Failed to set the volume: %s.' % (v_M,))
+        if self.player and self._length:
+            self._sliding = True  # slider moving, see .OnTick
+            self.after_cancel(self._tick_4)
+            t = self.timeSlider.get()
+            self._tick_4 = self.after_idle(self._set_time, t * _TICK_MS)
+            self._set_buttons(t)
+            self._debug(self.OnTime, tensecs=t)
 
-    def showError(self, message):
+    def OnZoomIn(self, *unused):
+        '''Zoom in 25%.
+        '''
+        self._set_zoom(1.25)
+        self._debug(self.OnZoomIn)
+
+    def OnZoomOut(self, *unused):
+        '''Zoom out 20%.
+        '''
+        self._set_zoom(0.80)
+        self._debug(self.OnZoomOut)
+
+    def _pause_play(self, playing):
+        # re-label menu item and button, adjust callbacks
+        p = 'Pause' if playing else 'Play'
+        c = self.OnPlay if playing is None else self.OnPause  # PYCHOK attr
+        self.playButton.config(label=p, command=c)
+        self.playItem.config(label=p, command=c)
+        self.muteButton.disabled(False)
+        self.muteItem.disabled(False)
+        self._stopped = self._opaque = False
+        self._set_buttons(self.timeSlider.get())
+        self._set_opacity()  # no re-label
+        self._set_volume()
+        self._set_aspect(True)
+
+    def _play(self, video):
+        # helper for OnOpen and OnPlay
+        if os.path.isfile(video):  # Creation
+            m = self.Instance.media_new(str(video))  # unicode
+            p = self.player
+            p.set_media(m)
+            t = '%s - %s' % (self._title, os.path.basename(video))
+            self.videoPanel.title(t)
+#           self.buttonsPanel.title(t)
+
+            # get the window handle for VLC to render the video
+            h = self.videoCanvas.winfo_id()  # .winfo_visualid()?
+            if _isWindows:
+                p.set_hwnd(h)
+            elif _isMacOS:
+                # (1) the handle on macOS *must* be an NSView
+                # (2) the video fills the entire panel, covering
+                # all frames, buttons, sliders, etc. inside it
+                ns = _GetNSView(h)
+                if ns:
+                    p.set_nsobject(ns)
+                else:  # no libtk: no video, only audio
+                    p.set_xwindow(h)
+            else:  # *nix, Xwindows
+                p.set_xwindow(h)  # fails on Windows
+            self.OnPlay(None)
+
+    def _reset(self):
+        # stop playing, clear panel
+        p = self.player
+        if p:
+            p.stop()
+            self.timeSlider.set(0)
+            self._pause_play(None)
+            self._sliding = False
+            self._stopped = True
+            self.OnOpacity()
+
+    def _set_aspect(self, force=False):
+        # set the video panel aspect ratio and re-anchor
+        p = self.player
+        if p and not self._isFull:
+            v = self.videoPanel
+            g, w, h, x, y = _geometry5(v)
+            if force or g != self._video_g:
+                self.after_cancel(self._tick_3)
+                a, b = p.video_get_size(0)  # often (0, 0)
+                if b > 0 and a > 0:
+                    # adjust the video panel ...
+                    if a > b:  # ... landscape height
+                        s = float(w) / a
+                        h = round(s * b)
+                    else:  # ... or portrait width
+                        s = float(h) / b
+                        w = round(s * a)
+                    _g = _geometry(v, w, h, x, y)
+                    self._video_g = _g
+                    self._scale_1X = s
+                    self._debug(self._set_aspect, b=b, a=a, force=force, g=g)
+                    if self._anchored and (force or _g != g):  # changed
+                        self._anchorPanels()
+                # redo periodically since (1) player.video_get_size()
+                # only returns non-zero width and height after playing
+                # for a while and (2) avoid too frequent updates during
+                # manual resizing of the video panel
+                self._tick_3 = self.after(500, self._set_aspect)
+
+    def _set_buttons(self, *tensecs):
+        # set the buttons panel title
+        s = self._length
+        if s and tensecs:
+            t =  tensecs[0]
+            t = _hms(t) if t < s else self._lengthstr
+            z = '' if self._zoomX == 1 else (' - %.1fX' % (self._zoomX,))
+            t = '%s - %s / %s%s' % (self._title, t, self._lengthstr, z)
+        else:  # reset panel title
+            t = '%s - %s' % (self._title, _BUTTONS)
+            self._length = 0
+#           self._lengthstr = ''
+        self.buttonsPanel.title(t)
+
+    def _set_opacity(self, *percent):  # 100% fully opaque
+        # set and re-label the opacity, panels and menu item
+        if percent:
+            self._opacity = p = percent[0]
+        else:
+            p = self._opacity
+        a = max(0.2, min(1, p * 1e-2))
+        self.videoPanel.attributes('-alpha', a if self._stopped else 1)
+        self.buttonsPanel.attributes('-alpha', a)
+#       if _isMacOS:  # <https://TkDocs.com/tutorial/windows.html>
+#           self.buttonsPanel.attributes('-transparent', a)
+        s = _OPACITY % (p,)
+        self.opaqueItem.config(label=s)
+        if self._opaque or self._stopped:
+            self._set_percent(p, label=s)
+
+    def _set_percent(self, percent, **cfg):
+        # set and re-label the slider
+        self.percentSlider.config(**cfg)
+        self.percentSlider.set(percent)
+
+    def _set_rate(self, factor):
+        # change the video rate
+        p = self.player
+        if p:
+            r = p.get_rate() * factor
+            r = max(0.2, min(10.0, r)) if r > 0 else 1.0
+            p.set_rate(r)
+            self._rate = r
+
+    def _set_time(self, millisecs):
+        # set player to time
+        p = self.player
+        if p:
+            p.set_time(millisecs)
+        self._sliding = False  # see .OnTick
+
+    def _set_volume(self, *volume):
+        # set and re-label the volume
+        if volume:
+            self._volume = v = volume[0]
+        else:
+            v = self._volume
+        m = ' (Muted)' if self._muted else ''
+        V = '%s %s%%' % (_VOLUME, v)
+        self._set_percent(v, label=V + m)
+        p = self.player
+        if p and p.is_playing() and not self._stopped:
+            # .audio_set_volume returns 0 on success, -1 otherwise,
+            # e.g. if the player is stopped or doesn't have media
+            if p.audio_set_volume(v):  # and p.get_media():
+                self._showError('set ' + V)
+
+    def _set_zoom(self, factor):
+        # zoom the video in/out, see cocoavlc.py
+        p = self.player
+        if p:
+            x = self._zoomX * factor
+            if x > 1:
+                s = x * self._scale_1X
+            else:
+                s, x = 0.0, 1.0
+            p.video_set_scale(s)
+#           self.videoPanel.update_idletasks()
+            self._scale = s  # = p.video_get_scale()
+            self._zoomX = x
+            if _isMacOS:
+                self._wiggle()
+
+    def _showError(self, verb):
         '''Display a simple error dialog.
         '''
-        self.OnStop()
-        showerror(self.parent.title(), message)
+        t = 'Unable to %s' % (verb,)
+        showerror(self._title, t)
+        # sys.exit(t)
+
+    def _VideoPanel(self):
+        # create panel to play video
+        v = ttk.Frame(self.parent)
+        c = Tk.Canvas(v)  # takefocus=True
+        c.pack(fill=Tk.BOTH, expand=1)
+        v.pack(fill=Tk.BOTH, expand=1)
+        v.update_idletasks()
+
+        self.videoCanvas = c
+        self.videoFrame  = v
+        # root is used for updates, not ...
+        return self.parent  # ... the frame
+
+    def _wiggle(self, d=4):
+        # wiggle the video to fill the window on macOS
+        if not self._isFull:
+            v = self.videoPanel
+            g, w, h, x, y = _geometry5(v)
+            w = int(w) + d
+            # x = int(x) - d
+            # h = int(h) + d
+            _g = _geometry(v, w, h, x, y)
+            if _g != g:
+                self.after_idle(_geometry, v, g)
+                self._video_g = ''
+        if d > 1:  # repeat a few times
+            self.after(100, self._wiggle, d - 1)
+
+
+def print_version(name=''):  # imported by psgvlc.py
+    # show all versions, this module, tkinter, libtk, vlc.py, libvlc, etc.
+
+    # sample output on macOS:
+
+    # % python3 ./tkvlc.py -v
+    # tkvlc.py: 22.12.12
+    # tkinter: 8.6
+    # libTk: /Library/Frameworks/Python.framework/Versions/3.11/lib/libtk8.6.dylib
+    # is_TK: isAquaTk, isCocoaTk, aqua
+    # vlc.py: 3.0.12119 (Mon May 31 18:25:17 2021 3.0.12)
+    # libVLC: 3.0.16 Vetinari (0x3001000)
+    # plugins: /Applications/VLC.app/Contents/MacOS/plugins
+    # Python: 3.11.0 (64bit) macOS 13.0.1 arm64
+
+    # PS C: python3 ./tkvlc.py -v
+    # tkvlc.py: 22.12.12
+    # tkinter: 8.6
+    # libTk: N/A
+    # is_TK: win32
+    # vlc.py: 3.0.12119 (Mon May 31 18:25:17 2021 3.0.12)
+    # libVLC: 3.0.18 Vetinari (0x3001200)
+    # plugins: C:\Program Files\VideoLAN\VLC
+    # Python: 3.11.0 (64bit) Windows 10
+
+    if _isMacOS:
+        from idlelib import macosx
+        m = macosx.__dict__
+        t = tuple(sorted(n for n, t in m.items() if n.startswith('is') and
+                                                    n.endswith('Tk') and
+                                                    callable(t) and t()))
+    else:
+        t =  ()
+    try:  # private property
+        t += Tk.Tk()._windowingsystem,
+    except AttributeError:
+        pass
+    t = ', '.join(t) or 'n/a'
+
+    n = os.path.basename(name or __file__)
+    for t in ((n, __version__), (Tk.__name__, Tk.TkVersion), ('libTk', libtk), ('is_Tk', t)):
+        print('%s: %s' % t)
+
+    try:
+        vlc.print_version()
+        vlc.print_python()
+    except AttributeError:
+        try:
+            os.system(sys.executable + ' -m vlc -v')
+        except OSError:
+            pass
 
 
 if __name__ == '__main__':  # MCCABE 13
@@ -648,42 +1250,28 @@ if __name__ == '__main__':  # MCCABE 13
     while len(sys.argv) > 1:
         arg = sys.argv.pop(1)
         if arg.lower() in ('-v', '--version'):
-            # show all versions, this vlc.py, libvlc, etc. (sample output on macOS):
-            # % python3 ./tkvlc.py -v
-            # tkvlc.py: 22.11.10
-            # tkinter: 8.6
-            # libTk: /Library/Frameworks/Python.framework/Versions/3.11/lib/libtk8.6.dylib
-            # vlc.py: 3.0.12119 (Mon May 31 18:25:17 2021 3.0.12)
-            # libVLC: 3.0.16 Vetinari (0x3001000)
-            # plugins: /Applications/VLC.app/Contents/MacOS/plugins
-            # Python: 3.11.0 (64bit) macOS 13.0.1 arm64
-            for t in ((_argv0, __version__), (Tk.__name__, Tk.TkVersion), ('libTk', libtk)):
-                print('%s: %s' % t)
-            try:
-                vlc.print_version()
-                vlc.print_python()
-            except AttributeError:
-                pass
+            print_version()
             sys.exit(0)
         elif '-debug'.startswith(arg) and len(arg) > 2:
             _debug = True
-        elif '-dragging'.startswith(arg) and len(arg) > 2:
-            _dragging = True  # detect dragging in buttons panel for Buttons Up/Down
         elif arg.startswith('-'):
-            print('usage: %s  [-v | --version]  [-debug]  [-dragging]  [<video_file_name>]' % (_argv0,))
+            print('usage: %s  [-v | --version]  [-debug]  [<video_file_name>]' % (_argv0,))
             sys.exit(1)
         elif arg:  # video file
             _video = os.path.expanduser(arg)
             if not os.path.isfile(_video):
-                print('%s error: no such file: %r' % (_argv0, arg))
+                print('%s error, no such file: %r' % (_argv0, arg))
                 sys.exit(1)
 
-    # Create a Tk.App() to handle the windowing event loop
-    root = Tk.Tk()
+    root = Tk.Tk()  # create a Tk.App()
     player = Player(root, video=_video, debug=_debug)
-    root.protocol('WM_DELETE_WINDOW', player.OnClose)  # XXX unnecessary (on macOS)
-    if _isWindows:  # see <https://GitHub.com/python/cpython/blob/3.11/Lib/tkinter/__init__.py>
+    if _isWindows:  # see function _test() at the bottom of ...
+        # <https://GitHub.com/python/cpython/blob/3.11/Lib/tkinter/__init__.py>
         root.iconify()
         root.update()
         root.deiconify()
-    root.mainloop()
+        root.mainloop()  # forever
+        root.destroy()  # this is necessary on Windows to avoid ...
+        # ... Fatal Python Error: PyEval_RestoreThread: NULL tstate
+    else:
+        root.mainloop()  # forever


### PR DESCRIPTION
Added a number of private classes to deal with `Tcl/Tk/tkinter` idiosyncrasies and differences on Windows and macOS.

On macOS, most `tkinter` calls seem delayed making it necessary to morph such calls into events (with `tkinter.after*` functions).

Changed the anchoring of the buttons and video panel by making both separate, movable windows.  Dragging and resizing each window now works smoothly and correctly on Windows and macOS.

Added menu options to change zoom, rate and opacity.  However, the zoom and rate items are disabled on macOS due to poor behavior (still unresolved).