### PR TITLE
Fix Regression in [OUT] parameters handling (Issue #287)

### DIFF
--- a/generator/generate.py
+++ b/generator/generate.py
@@ -700,6 +700,8 @@ class Func(_Source):
         r = []
         v = []
         block = None
+        block_is_params = False
+        last_param_name = None
 
         lines = self.base_sphinx_format(self.docs)
 
@@ -712,6 +714,7 @@ class Func(_Source):
                 if block is None:
                     indent = ""
                     block = heads
+                    block_is_params = False
 
                 # Check whether there is a blonk line right before the @code line.
                 # If not, add one (needed for sphinx to properly display the list).
@@ -726,22 +729,35 @@ class Func(_Source):
                     i += 1
 
                 block.append("")
+
                 block = None
+                block_is_params = False
             elif ":param" in line:
+                last_param_name = line.split()[1]
+
                 if _OUT_ in line:
                     line = line.replace(_PNTR_, "")
-                    out.append(line.split()[1])
+                    out.append(last_param_name)
+
                 params.append(param_re.sub(r":param \g<param_name>:", line))
+
                 block = params
+                block_is_params = True
             elif ":return:" in line:
                 r.append(line)
+
                 block = r
+                block_is_params = False
             elif ":version:" in line:
                 v.append(line)
+
                 block = v
+                block_is_params = False
             elif ":bug:" in line:
                 b.append(line)
+
                 block = b
+                block_is_params = False
             elif "@code" in line:  # we are dealing with a code block
                 # Check whether there is a blonk line right before the @code line.
                 # If not, add one (needed for sphinx to properly display the code block).
@@ -781,20 +797,30 @@ class Func(_Source):
                     heads.append(line.replace("@endcode", "").strip())
 
                 block = None
+                block_is_params = False
             elif ".. note::" in line:
                 if i - 1 >= 0 and lines[i - 1]:
                     heads.append("")
+
                 heads.append(line)
+
                 block = heads
+                block_is_params = False
             elif ".. warning::" in line:
                 heads.append(line)
+
                 block = heads
+                block_is_params = False
             elif block is not None:
+                if block_is_params and _OUT_ in line:
+                    out.append(last_param_name)
+
                 if line:
                     block.append(_INDENT_ + line)
                 else:
                     block.append(line)
                     block = None
+                    block_is_params = False
             else:
                 heads.append(line)
 

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -667,10 +667,13 @@ class Func(_Source):
                 self.dump()
                 sys.stderr.write(self.docs + "\n")
 
-    def dump(self, indent_lvl=0):
+    def dump(self, indent_lvl=0, out=()):
         for _ in range(indent_lvl):
             sys.stderr.write(_INDENT_)
-        sys.stderr.write("%s (%s): %s\n" % (self.name, self.type, self.source))
+
+        t = "Out" if self.name in out else ""
+        sys.stderr.write("%s (%s): %s %s\n" % (self.name, self.type, self.source, t))
+
         for p in self.pars:
             p.dump(indent_lvl + 1, self.out)
 


### PR DESCRIPTION
I identified and fixed two bugs:

1. During bindings generation (`PythonGenerator.generate_funcs` and `PythonGenerator.generate_func_pointer_decorator`), `Func.docs_in_sphinx_format` was called _after_ `Par.flags`, when the former fills the `out` member of `Func`, which determines the output of `Par.flags`. This resulted in out parameters being ignored, even though they are properly gathered by `Func.docs_in_sphinx_format`. Actually, some are still taken into account, because in `Par.flags`, some pointer types are hard-coded to be considered out parameters (this hard-coding may not be necessary anymore).

    This issue is fixed by commit "Partially fix regression in [OUT] parameter handling".
    
    The functions concerned by the fix are:
    
    - `libvlc_log_get_context`
    - `libvlc_log_get_object`

2. `Func.docs_in_sphinx_format` did not properly gather all out parameters. It failed to gather those that have documentation spanning multiple lines. As the `[OUT]` flag is often (always?) present at the end of a parameter's documentation, it was missed in those cases. 

    This issue is fixed by commit "Fix regression in [OUT] parameters handling".
    
    The functions concerned by the fix are:
    
    - `libvlc_media_discoverer_list_get`
    - `libvlc_media_player_get_full_chapter_descriptions`
    -  `libvlc_media_player_get_full_title_descriptions`
    - `libvlc_media_slaves_get`
    - `libvlc_media_tracks_get`
    - `libvlc_renderer_discoverer_list_get`
    
    What I have _not_ done is change `generator/templates/override.py`, which has calls to:
    
    - `libvlc_media_player_get_full_chapter_descriptions`
    - `libvlc_media_player_get_full_title_descriptions`
    - `libvlc_media_tracks_get`
    
    that now take an incorrect number of arguments.
    Tests fail for this reason.
  
Otherwise, the first commit ("Fix dumping of parameters that are Func and not Par") fixes a small bug in the code for dumping in debug mode.