### PR TITLE
Generator support for libvlc_time_t* pointer types (Fixes VLC 4.0 build)

### DIFF
--- a/generator/generate.py
+++ b/generator/generate.py
@@ -2103,6 +2103,7 @@ class PythonGenerator(_Generator):
         "libvlc_media_track_info_t**": "ctypes.POINTER(ctypes.c_void_p)",
         "libvlc_rectangle_t*": "ctypes.POINTER(Rectangle)",
         "libvlc_time_t": "ctypes.c_longlong",
+        "libvlc_time_t*": "ctypes.POINTER(ctypes.c_longlong)",
         "libvlc_track_description_t*": "ctypes.POINTER(TrackDescription)",
         "libvlc_title_description_t**": "ctypes.POINTER(TitleDescription)",
         "libvlc_title_description_t***": "ctypes.POINTER(ctypes.POINTER(TitleDescription))",


### PR DESCRIPTION
The generator currently fails when building against VLC 4.0-dev headers due to the unmapped type `libvlc_time_t*` used in `libvlc_media_player_get_abloop`.

This PR adds the necessary type mapping to `ctypes.POINTER(ctypes.c_longlong)`.

Closes #298